### PR TITLE
update for titiler 0.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 * Unify *reader/writer* db pools to `request.app.state.dbpool`
 * rename `PostgresSettings.db_max_inactive_conn_lifetime` to `PostgresSettings.max_idle`
 * remove `PostgresSettings().reader_connection_string` and `PostgresSettings().writer_connection_string`. Replaced with `PostgresSettings().connection_string`
+* update titiler requirement (>= 0.4)
 
 ## 0.1.0.a1 (2021-09-15) Pre-Release
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 * rename `PostgresSettings.db_max_inactive_conn_lifetime` to `PostgresSettings.max_idle`
 * remove `PostgresSettings().reader_connection_string` and `PostgresSettings().writer_connection_string`. Replaced with `PostgresSettings().connection_string`
 * update titiler requirement (>= 0.4)
+* add `filter-lang` in Search model to support newer PgSTAC (with CQL-2)
 
 ## 0.1.0.a1 (2021-09-15) Pre-Release
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@
 
 `TiTiler.PgSTAC` is a [titiler](https://github.com/developmentseed/titile) extension which connect to [pgstac](https://github.com/stac-utils/pgstac) STAC database in order to create **mosaics** in response to a STAC-api `search` query.
 
-
 ## Installation
 
 To install from PyPI and run:
@@ -50,6 +49,10 @@ $ git clone https://github.com/stac-utils/titiler-pgstac.git
 $ cd titiler-pgstac
 $ python -m pip install -e .
 ```
+
+### `PgSTAC` version
+
+`titiler.pgstac` depends on `pgstac >=0.3.4` (https://github.com/stac-utils/pgstac/blob/main/CHANGELOG.md#v034).
 
 ### `psycopg` requirement
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
   database:
     container_name: stac-db
     platform: linux/amd64
-    image: ghcr.io/stac-utils/pgstac:v0.3.6
+    image: ghcr.io/stac-utils/pgstac:v0.4.0
     environment:
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -27,13 +27,17 @@ Example:
 
 - `https://myendpoint/register`
 
-```
-curl -X 'POST' 'http://127.0.0.1:8000/register' -d '{"collections":["landsat-c2l2-sr"], "bbox":[-123.75,34.30714385628804,-118.125,38.82259097617712]}' | jq
+```bash
+curl -X 'POST' 'http://127.0.0.1:8000/register' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{"collections":["landsat-c2l2-sr"], "bbox":[-123.75,34.30714385628804,-118.125,38.82259097617712], "filter-lang": "cql-json"}' | jq
 {
-  "searchid": "f1ed59f0a6ad91ed80ae79b7b52bc707",
-  "metadata": "http://127.0.0.1:8000/f1ed59f0a6ad91ed80ae79b7b52bc707/info",
-  "tiles": "http://127.0.0.1:8000/f1ed59f0a6ad91ed80ae79b7b52bc707/tilejson.json"
+  "searchid": "5181a09f58f348db706aa761cd594ce7",
+  "metadata": "http://127.0.0.1:8000/5181a09f58f348db706aa761cd594ce7/info",
+  "tiles": "http://127.0.0.1:8000/5181a09f58f348db706aa761cd594ce7/tilejson.json"
 }
+
+# or using CQL2
+curl -X 'POST' 'http://127.0.0.1:8081/register' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{"filter": {"op": "=", "args": [{"property": "collection"}, "landsat-c2l2-sr"]}}' | jq
+
 ```
 
 ### Search metadata
@@ -47,10 +51,10 @@ Example:
 
 - `https://myendpoint/f1ed59f0a6ad91ed80ae79b7b52bc707/info`
 
-```
+```bash
 curl 'http://127.0.0.1:8000/f1ed59f0a6ad91ed80ae79b7b52bc707/info' | jq
 {
-  "hash": "f1ed59f0a6ad91ed80ae79b7b52bc707",
+  "hash": "5181a09f58f348db706aa761cd594ce7",
   "search": {
     "bbox": [
       -123.75,
@@ -60,15 +64,14 @@ curl 'http://127.0.0.1:8000/f1ed59f0a6ad91ed80ae79b7b52bc707/info' | jq
     ],
     "collections": [
       "landsat-c2l2-sr"
-    ]
+    ],
+    "filter-lang": "cql-json"
   },
   "_where": "(((collection_id = ANY ( '{landsat-c2l2-sr}'::text[] )) AND st_intersects(geometry, '0103000020E610000001000000050000000000000000F05EC055F6687D502741400000000000F05EC02D553EA94A6943400000000000885DC02D553EA94A6943400000000000885DC055F6687D502741400000000000F05EC055F6687D50274140'::geometry)))",
   "orderby": "datetime DESC, id DESC",
-  "lastused": "2021-09-06T09:33:41.676272+00:00",
+  "lastused": "2021-12-13T16:43:55.959925+00:00",
   "usecount": 2,
-  "statslastupdated": "2021-09-06T09:33:34.892161+00:00",
-  "estimated_count": 1,
-  "total_count": 0
+  "metadata": {}
 }
 ```
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -12,13 +12,23 @@ The first step of the mosaic create is to register a `Search` query within the P
 
 #### Example
 
-```
-curl -X 'POST' 'http://127.0.0.1:8000/register' -H 'accept: application/json' -H 'Content-Type: application/json'
--d '{"collections":["landsat-c2l2-sr"], "bbox":[-123.75,34.30714385628804,-118.125,38.82259097617712]}' | jq
+```bash
+curl -X 'POST' 'http://127.0.0.1:8081/register' -H 'accept: application/json' -H 'Content-Type: application/json'
+-d '{"collections":["landsat-c2l2-sr"], "bbox":[-123.75,34.30714385628804,-118.125,38.82259097617712], "filter-lang": "cql-json"}' | jq
+
 {
   "searchid": "f1ed59f0a6ad91ed80ae79b7b52bc707",
   "metadata": "http://127.0.0.1:8000/f1ed59f0a6ad91ed80ae79b7b52bc707/info",
   "tiles": "http://127.0.0.1:8000/f1ed59f0a6ad91ed80ae79b7b52bc707/tilejson.json"
+}
+
+# Or using CQL-2
+curl -X 'POST' 'http://127.0.0.1:8000/register' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{"filter": {"op": "and", "args": [{"op": "=", "args": [{"property": "collection"}, "landsat-c2l2-sr"]}, {"op": "s_intersects", "args": [{"property": "geometry"}, {"coordinates": [[[-123.75, 34.30714385628804], [-123.75, 38.82259097617712], [-118.125, 38.82259097617712], [-118.125, 34.30714385628804], [-123.75, 34.30714385628804]]], "type": "Polygon"}]}]}}' | jq
+
+{
+  "searchid": "5181a09f58f348db706aa761cd594ce7",
+  "metadata": "http://127.0.0.1:8000/5181a09f58f348db706aa761cd594ce7/info",
+  "tiles": "http://127.0.0.1:8000/5181a09f58f348db706aa761cd594ce7/tilejson.json"
 }
 ```
 

--- a/docs/notebooks/demo.ipynb
+++ b/docs/notebooks/demo.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## titiler.PgSTAC Demo\n",
     "\n",
@@ -26,12 +27,13 @@
     "$ pypgstac load collections tests/fixtures/noaa-emergency-response.json --dsn postgresql://username:password@localhost:5439/postgis --method insert \n",
     "$ pypgstac load items tests/fixtures/noaa-eri-nashville2020.json --dsn postgresql://username:password@localhost:5439/postgis --method insert\n",
     "```\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import json\n",
     "import requests\n",
@@ -42,13 +44,13 @@
     "endpoint = \"http://0.0.0.0:8081\"\n",
     "\n",
     "print(requests.get(\"http://0.0.0.0:8081/healthz\").json())"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "\n",
     "# bounds of the noaa-eri-nashville2020.json items\n",
@@ -71,26 +73,27 @@
     ")\n",
     "geo_json.add_to(m)\n",
     "m"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Register Search query"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "search_request = {\n",
     "    # Filter collection\n",
     "    \"collections\": [\"noaa-emergency-response\"],\n",
     "    # limit bounds of the known items (note: the bbox will also be used in the tilejson response)\n",
     "    \"bbox\": bounds,\n",
+    "    \"filter-lang\": \"clq-json\",\n",
     "}\n",
     "\n",
     "reg_response = requests.post(\n",
@@ -100,56 +103,56 @@
     "print(reg_response)\n",
     "\n",
     "searchid = reg_response[\"searchid\"]"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Get Search Metadata"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "info_response = requests.get(f\"{endpoint}/{searchid}/info\").json()\n",
     "print(info_response)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Get TileJSON\n",
     "\n",
     "Note: to return a valid tilejson document you'll need to pass either the `assets` or `expression` option."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "tj_response = requests.get(f\"{endpoint}/{searchid}/tilejson.json?assets=cog\").json()\n",
     "print(tj_response)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Load tiles"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "m = Map(\n",
     "    location=((bounds[1] + bounds[3]) / 2,(bounds[0] + bounds[2]) / 2),\n",
@@ -173,9 +176,14 @@
     ")\n",
     "aod_layer.add_to(m)\n",
     "m"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": []
   }
  ],
  "metadata": {
@@ -183,8 +191,8 @@
    "hash": "e0a12c78cd70db9ff05ed68287a27ffcdd32788e19bdb884235a47fc6f52d8ad"
   },
   "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.8.2 64-bit ('py38': venv)"
+   "display_name": "Python 3.8.2 64-bit ('py38': venv)",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extra_reqs = {
         "pytest-cov",
         "pytest-asyncio",
         "requests",
-        "pypgstac",
+        "pypgstac>=0.4,<0.5",
         "asyncpg",
     ],
     # https://www.psycopg.org/psycopg3/docs/api/pq.html#pq-module-implementations

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ with open("README.md") as f:
     long_description = f.read()
 
 inst_reqs = [
-    "titiler.core>=0.3.8,<0.4",
-    "titiler.mosaic>=0.3.8,<0.4",
+    "titiler.core>=0.4.0,<0.5",
+    "titiler.mosaic>=0.4.0,<0.5",
     "geojson-pydantic>=0.3.1,<0.4",
     "stac-pydantic==2.0.*",
 ]

--- a/tests/test_titiler_pgstac.py
+++ b/tests/test_titiler_pgstac.py
@@ -4,13 +4,13 @@ from unittest.mock import patch
 
 from .conftest import mock_rasterio_open, parse_img
 
-search_no_bbox = "076233571a03a39e92cc92953f97f752"
-search_bbox = "18a1a6f23de16464c84c6bf0b4406215"
+search_no_bbox = "d7f31eb5c11b1b7fa46990ef2de7b136"
+search_bbox = "ef44755ef0ecfe9a3be58b6e94ebc264"
 
 
 def test_register(app):
     """Register Search requests."""
-    query = {"collections": ["noaa-emergency-response"]}
+    query = {"collections": ["noaa-emergency-response"], "filter-lang": "cql-json"}
     response = app.post("/register", json=query)
     assert response.status_code == 200
 
@@ -22,6 +22,7 @@ def test_register(app):
     query = {
         "collections": ["noaa-emergency-response"],
         "bbox": [-85.535, 36.137, -85.465, 36.179],
+        "filter-lang": "cql-json",
     }
     response = app.post("/register", json=query)
     assert response.status_code == 200
@@ -39,7 +40,10 @@ def test_info(app):
     resp = response.json()
 
     assert "hash" in resp
-    assert resp["search"] == {"collections": ["noaa-emergency-response"]}
+    assert resp["search"] == {
+        "collections": ["noaa-emergency-response"],
+        "filter-lang": "cql-json",
+    }
     assert resp["metadata"] == {}
 
 

--- a/tests/test_titiler_pgstac.py
+++ b/tests/test_titiler_pgstac.py
@@ -51,7 +51,7 @@ def test_assets_for_point(app):
     assert len(resp) == 1
     assert list(resp[0]) == ["id", "bbox", "assets"]
 
-    # no assets found outside the query bbox
+    # no assets found outside the mosaic bbox
     response = app.get(f"/{search_bbox}/-85.6358,36.1624/assets")
     assert response.status_code == 200
     resp = response.json()
@@ -159,5 +159,6 @@ def test_tiles(rio, app):
     assert meta["width"] == 256
     assert meta["height"] == 256
 
+    # tile is outside mosaic bbox, it should return 404 (NoAssetFoundError)
     response = app.get(f"/tiles/{search_bbox}/{z}/{x}/{y}?assets=cog")
     assert response.status_code == 404

--- a/tests/test_titiler_pgstac.py
+++ b/tests/test_titiler_pgstac.py
@@ -166,3 +166,133 @@ def test_tiles(rio, app):
     # tile is outside mosaic bbox, it should return 404 (NoAssetFoundError)
     response = app.get(f"/tiles/{search_bbox}/{z}/{x}/{y}?assets=cog")
     assert response.status_code == 404
+
+
+@patch("rio_tiler.io.cogeo.rasterio")
+def test_cql2(rio, app):
+    """Test with cql2."""
+    rio.open = mock_rasterio_open
+
+    query = {
+        "filter": {
+            "op": "=",
+            "args": [{"property": "collection"}, "noaa-emergency-response"],
+        }
+    }
+    response = app.post("/register", json=query)
+    assert response.status_code == 200
+    resp = response.json()
+    assert resp["metadata"]
+    assert resp["tiles"]
+
+    cql2_id = resp["searchid"]
+
+    response = app.get(f"/{cql2_id}/info")
+    assert response.status_code == 200
+    resp = response.json()
+    assert "hash" in resp
+    assert resp["search"] == {
+        "filter": {
+            "op": "=",
+            "args": [{"property": "collection"}, "noaa-emergency-response"],
+        }
+    }
+    assert resp["metadata"] == {}
+
+    response = app.get(f"/{cql2_id}/-85.6358,36.1624/assets")
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 1
+    assert list(resp[0]) == ["id", "bbox", "assets"]
+    assert resp[0]["id"] == "20200307aC0853900w361030"
+
+    response = app.get(f"/{cql2_id}/15/8589/12849/assets")
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 1
+    assert list(resp[0]) == ["id", "bbox", "assets"]
+    assert resp[0]["id"] == "20200307aC0853900w361030"
+
+    response = app.get(f"/{cql2_id}/tilejson.json?assets=cog")
+    assert response.headers["content-type"] == "application/json"
+    assert response.status_code == 200
+    resp = response.json()
+    assert resp["name"] == cql2_id
+    assert resp["minzoom"] == 0
+    assert resp["maxzoom"] == 24
+    assert round(resp["bounds"][0]) == -180
+    assert "?assets=cog" in resp["tiles"][0]
+
+    z, x, y = 15, 8589, 12849
+    response = app.get(f"/tiles/{cql2_id}/{z}/{x}/{y}?assets=cog")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/jpeg"
+    meta = parse_img(response.content)
+    assert meta["width"] == 256
+    assert meta["height"] == 256
+
+
+@patch("rio_tiler.io.cogeo.rasterio")
+def test_cql2_with_geometry(rio, app):
+    """Test with cql2 with geometry filter."""
+    rio.open = mock_rasterio_open
+    # Filter with geometry
+    query = {
+        "filter": {
+            "op": "and",
+            "args": [
+                {
+                    "op": "=",
+                    "args": [{"property": "collection"}, "noaa-emergency-response"],
+                },
+                {
+                    "op": "s_intersects",
+                    "args": [
+                        {"property": "geometry"},
+                        {
+                            "coordinates": [
+                                [
+                                    [-85.535, 36.137],
+                                    [-85.535, 36.179],
+                                    [-85.465, 36.179],
+                                    [-85.465, 36.137],
+                                    [-85.535, 36.137],
+                                ]
+                            ],
+                            "type": "Polygon",
+                        },
+                    ],
+                },
+            ],
+        }
+    }
+    response = app.post("/register", json=query)
+    assert response.status_code == 200
+    resp = response.json()
+    assert resp["metadata"]
+    assert resp["tiles"]
+
+    cql2_id = resp["searchid"]
+
+    response = app.get(f"/{cql2_id}/info")
+    assert response.status_code == 200
+    resp = response.json()
+    assert "hash" in resp
+    assert resp["metadata"] == {}
+
+    # point is outside the geometry filter
+    response = app.get(f"/{cql2_id}/-85.6358,36.1624/assets")
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 0
+
+    # tile is outside the geometry filter
+    response = app.get(f"/{cql2_id}/15/8589/12849/assets")
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 0
+
+    # tile is outside the geometry filter
+    z, x, y = 15, 8589, 12849
+    response = app.get(f"/tiles/{cql2_id}/{z}/{x}/{y}?assets=cog")
+    assert response.status_code == 404

--- a/tests/test_titiler_pgstac.py
+++ b/tests/test_titiler_pgstac.py
@@ -54,6 +54,13 @@ def test_assets_for_point(app):
     resp = response.json()
     assert len(resp) == 1
     assert list(resp[0]) == ["id", "bbox", "assets"]
+    assert resp[0]["id"] == "20200307aC0853900w361030"
+
+    # make sure we can find assets when having both bbox and geometry
+    response = app.get(f"/{search_bbox}/-85.5,36.1624/assets")
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 2
 
     # no assets found outside the mosaic bbox
     response = app.get(f"/{search_bbox}/-85.6358,36.1624/assets")
@@ -70,6 +77,12 @@ def test_assets_for_tile(app):
     assert len(resp) == 1
     assert list(resp[0]) == ["id", "bbox", "assets"]
     assert resp[0]["id"] == "20200307aC0853900w361030"
+
+    # make sure we can find assets when having both bbox and geometry
+    response = app.get(f"/{search_bbox}/15/8601/12849/assets")
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 2
 
     # no assets found outside the query bbox
     response = app.get(f"/{search_bbox}/15/8589/12849/assets")
@@ -280,11 +293,23 @@ def test_cql2_with_geometry(rio, app):
     assert "hash" in resp
     assert resp["metadata"] == {}
 
+    # make sure we can find assets when having both geometry filter and geometry
+    response = app.get(f"/{cql2_id}/15/8601/12849/assets")
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 2
+
     # point is outside the geometry filter
     response = app.get(f"/{cql2_id}/-85.6358,36.1624/assets")
     assert response.status_code == 200
     resp = response.json()
     assert len(resp) == 0
+
+    # make sure we can find assets when having both geometry filter and geometry
+    response = app.get(f"/{cql2_id}/15/8601/12849/assets")
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 2
 
     # tile is outside the geometry filter
     response = app.get(f"/{cql2_id}/15/8589/12849/assets")

--- a/titiler/pgstac/factory.py
+++ b/titiler/pgstac/factory.py
@@ -329,7 +329,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                 with conn.cursor() as cursor:
                     cursor.execute(
                         "SELECT * FROM search_query(%s);",
-                        (body.json(exclude_none=True),),
+                        (body.json(exclude_none=True, by_alias=True),),
                     )
                     r = cursor.fetchone()
                     fields = list(map(lambda x: x[0], cursor.description))

--- a/titiler/pgstac/factory.py
+++ b/titiler/pgstac/factory.py
@@ -31,7 +31,7 @@ def PathParams(searchid: str = Path(..., description="Search Id")) -> str:
 
 
 @dataclass
-class PgSTACParams:
+class PgSTACParams(DefaultDependency):
     """PgSTAC parameters."""
 
     scan_limit: Optional[int] = Query(
@@ -55,22 +55,12 @@ class PgSTACParams:
         description="Skip any items that would show up completely under the previous items (defaults to True in PgSTAC).",
     )
 
-    # Future dependencies class in titiler 0.4.0
-    # Those 2 method enable dict unpacking `**PgSTACParams()`
-    def keys(self):
-        """Return keys."""
-        return self.__dict__.keys()
-
-    def __getitem__(self, key):
-        """Return value."""
-        return self.__dict__[key]
-
 
 @dataclass
 class MosaicTilerFactory(BaseTilerFactory):
     """Custom MosaicTiler for PgSTAC Mosaic Backend."""
 
-    reader: BaseBackend = PGSTACBackend
+    reader: Type[BaseBackend] = PGSTACBackend
     path_dependency: Callable[..., str] = PathParams
     layer_dependency: Type[DefaultDependency] = AssetsBidxExprParams
 
@@ -128,13 +118,13 @@ class MosaicTilerFactory(BaseTilerFactory):
             ),
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
-            render_params=Depends(self.render_dependency),
-            colormap=Depends(self.colormap_dependency),
             pixel_selection: PixelSelectionMethod = Query(
                 PixelSelectionMethod.first, description="Pixel selection method."
             ),
+            postprocess_params=Depends(self.process_dependency),
+            colormap=Depends(self.colormap_dependency),
+            render_params=Depends(self.render_dependency),
             pgstac_params: PgSTACParams = Depends(),
-            kwargs: Dict = Depends(self.additional_dependency),
         ):
             """Create map tile."""
             timings = []
@@ -159,12 +149,11 @@ class MosaicTilerFactory(BaseTilerFactory):
                             y,
                             z,
                             pixel_selection=pixel_selection.method(),
-                            threads=threads,
                             tilesize=tilesize,
-                            **layer_params.kwargs,
-                            **dataset_params.kwargs,
+                            threads=threads,
+                            **layer_params,
+                            **dataset_params,
                             **pgstac_params,
-                            **kwargs,
                         )
             timings.append(("dataread", round((t.elapsed - mosaic_read) * 1000, 2)))
 
@@ -172,19 +161,15 @@ class MosaicTilerFactory(BaseTilerFactory):
                 format = ImageType.jpeg if data.mask.all() else ImageType.png
 
             with Timer() as t:
-                image = data.post_process(
-                    in_range=render_params.rescale_range,
-                    color_formula=render_params.color_formula,
-                )
+                image = data.post_process(**postprocess_params)
             timings.append(("postprocess", round(t.elapsed * 1000, 2)))
 
             with Timer() as t:
                 content = image.render(
-                    add_mask=render_params.return_mask,
                     img_format=format.driver,
                     colormap=colormap,
                     **format.profile,
-                    **render_params.kwargs,
+                    **render_params,
                 )
             timings.append(("format", round(t.elapsed * 1000, 2)))
 
@@ -229,13 +214,13 @@ class MosaicTilerFactory(BaseTilerFactory):
             ),
             layer_params=Depends(self.layer_dependency),  # noqa
             dataset_params=Depends(self.dataset_dependency),  # noqa
-            render_params=Depends(self.render_dependency),  # noqa
-            colormap=Depends(self.colormap_dependency),  # noqa
             pixel_selection: PixelSelectionMethod = Query(
                 PixelSelectionMethod.first, description="Pixel selection method."
             ),  # noqa
+            postprocess_params=Depends(self.process_dependency),  # noqa
+            colormap=Depends(self.colormap_dependency),  # noqa
+            render_params=Depends(self.render_dependency),  # noqa
             pgstac_params: PgSTACParams = Depends(),  # noqa
-            kwargs: Dict = Depends(self.additional_dependency),  # noqa
         ):
             """Return TileJSON document for a SearchId."""
             with request.app.state.dbpool.connection() as conn:

--- a/titiler/pgstac/models.py
+++ b/titiler/pgstac/models.py
@@ -5,7 +5,7 @@ Note: This is mostly a copy of https://github.com/stac-utils/stac-fastapi/blob/m
 """
 
 import operator
-from enum import auto
+from enum import Enum, auto
 from types import DynamicClassAttribute
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -17,9 +17,19 @@ from geojson_pydantic.geometries import (
     Point,
     Polygon,
 )
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, Field, root_validator, validator
 from stac_pydantic.shared import BBox
 from stac_pydantic.utils import AutoValueEnum
+
+
+class FilterLang(str, Enum):
+    """filter language.
+
+    ref: https://github.com/radiantearth/stac-api-spec/tree/master/fragments/filter#get-query-parameters-and-post-json-fields
+    """
+
+    cql_json = "cql-json"
+    cql_text = "cql-text"
 
 
 class Operator(str, AutoValueEnum):
@@ -48,7 +58,7 @@ class SearchQuery(BaseModel):
 
     Notes/Diff with standard model:
         - 'fields' is not in the Model because it's defined at the tiler level
-
+        - we don't set limit
     """
 
     collections: Optional[List[str]] = None
@@ -61,10 +71,12 @@ class SearchQuery(BaseModel):
     filter: Optional[Dict]
     datetime: Optional[str] = None
     sortby: Any
+    filter_lang: Optional[FilterLang] = Field(None, alias="filter-lang")
 
     class Config:
         """Config for model."""
 
+        use_enum_values = True
         extra = "allow"
 
     @root_validator(pre=True)


### PR DESCRIPTION
This PR Does:

- up titiler requirement to `0.4.0` 

Note: new titiler version changed a lot of `query-parameter` style and name see: https://github.com/developmentseed/titiler/discussions/396

For now the Tests fails because there has been a change in pgstac behaviour. When we register a Search request with a bbox we were expecting that requesting a tile outside the bbox would return empty items ... but it's no more the case with `0.4.0` 🤷‍♂️  cc @bitner