### PR TITLE
add metadata in search model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## 0.1.0.a2 (TDB) Pre-Release
 
 * Switch to **psycopg3**
+* add `filter-lang` in Search model to support newer PgSTAC (with CQL-2)
+* add `metadata` in Search model to allow forwarding metadata to the search query entry in PgSTAC
 
 **breaking changes**
 
@@ -10,7 +12,6 @@
 * rename `PostgresSettings.db_max_inactive_conn_lifetime` to `PostgresSettings.max_idle`
 * remove `PostgresSettings().reader_connection_string` and `PostgresSettings().writer_connection_string`. Replaced with `PostgresSettings().connection_string`
 * update titiler requirement (>= 0.4)
-* add `filter-lang` in Search model to support newer PgSTAC (with CQL-2)
 
 ## 0.1.0.a1 (2021-09-15) Pre-Release
 

--- a/titiler/pgstac/models.py
+++ b/titiler/pgstac/models.py
@@ -73,6 +73,9 @@ class SearchQuery(BaseModel):
     sortby: Any
     filter_lang: Optional[FilterLang] = Field(None, alias="filter-lang")
 
+    # Metadata associated with the search
+    metadata: Optional[Dict[str, Any]]
+
     class Config:
         """Config for model."""
 


### PR DESCRIPTION
closes #22 

This PR do:
- add `metadata` in Search model which will then be forwarded to the PgSTAC `search_query` function 