### PR TITLE
add metadata model

### DIFF
--- a/tests/test_titiler_pgstac.py
+++ b/tests/test_titiler_pgstac.py
@@ -394,4 +394,9 @@ async def test_query_with_metadata(app):
             "args": [{"property": "collection"}, "noaa-emergency-response"],
         }
     }
-    assert resp["metadata"] == {"name": "mymosaic", "minzoom": 1, "maxzoom": 2}
+    assert resp["metadata"] == {
+        "type": "mosaic",
+        "name": "mymosaic",
+        "minzoom": 1,
+        "maxzoom": 2,
+    }

--- a/titiler/pgstac/factory.py
+++ b/titiler/pgstac/factory.py
@@ -343,10 +343,13 @@ class MosaicTilerFactory(BaseTilerFactory):
             """Register a Search query."""
             search = body.json(
                 exclude_none=True,
-                exclude={"metadata"},
+                exclude={"metadata"},  # metadata is not part of the pgstac search model
                 by_alias=True,
             )
-            metadata = body.metadata or {}
+            if body.metadata:
+                metadata = body.metadata.dict(exclude_none=True)
+            else:
+                metadata = {}
 
             with request.app.state.dbpool.connection() as conn:
                 with conn.cursor() as cursor:

--- a/titiler/pgstac/models.py
+++ b/titiler/pgstac/models.py
@@ -54,6 +54,52 @@ class Operator(str, AutoValueEnum):
         return getattr(operator, self._value_)
 
 
+class SearchEnum(str, Enum):
+    """Metadata type."""
+
+    mosaic = "mosaic"
+
+
+class SearchMetadata(BaseModel):
+    """Metadata Model."""
+
+    type: SearchEnum = SearchEnum.mosaic
+
+    # WGS84 bounds
+    bounds: Optional[BBox]
+
+    # Min/Max zoom for WebMercatorQuad TMS
+    minzoom: Optional[int]
+    maxzoom: Optional[int]
+
+    # Name
+    name: Optional[str]
+
+    # List of available assets
+    assets: Optional[List[str]]
+
+    # Set of default configuration
+    # e.g
+    # {
+    #     "true_color": {
+    #         "assets": ["B4", "B3", "B2"],
+    #         "color_formula": "Gamma RGB 3.5 Saturation 1.7 Sigmoidal RGB 15 0.35",
+    #     },
+    #     "ndvi": {
+    #         "expression": "(B4-B3)/(B4+B3)",
+    #         "rescale": "-1,1",
+    #         "colormap_name": "viridis"
+    #     }
+    # }
+    defaults: Optional[Dict[str, Any]]
+
+    class Config:
+        """Config for model."""
+
+        use_enum_values = True
+        extra = "allow"
+
+
 class SearchQuery(BaseModel):
     """Search model.
 
@@ -75,7 +121,7 @@ class SearchQuery(BaseModel):
     filter_lang: Optional[FilterLang] = Field(None, alias="filter-lang")
 
     # Metadata associated with the search
-    metadata: Optional[Dict[str, Any]]
+    metadata: Optional[SearchMetadata]
 
     class Config:
         """Config for model."""


### PR DESCRIPTION
ref #30 

This PR adds a `SearchMetadata` model defining the `mosaic` metadata that could be provided by the user when `registering` a search request. 

#### Metadata

```js
{
    // OPTIONAL. Default: "mosaic" (No other value accepted for now). Describe the `type` of metadata. 
    "type": "mosaic",

    // OPTIONAL. Default: null.
    // The maximum extent of available map tiles. The bounds are represented in WGS:84
    // latitude and longitude values, in the order left, bottom, right, top.
    // Values may be integers or floating point numbers.
    "bounds": [ -180, -85.05112877980659, 180, 85.0511287798066 ],

    // OPTIONAL. Default: null.
    // An integer specifying the minimum zoom level.
    "minzoom": 0,

    // OPTIONAL. Default: null.
    // An integer specifying the maximum zoom level. MUST be >= minzoom.
    "maxzoom": 11,

    // OPTIONAL. Default: null. The name can contain any legal character.
    "name": "compositing",

    // OPTIONAL. Default: null. An array of available assets.
    "assets": ["image", "cog"],

    // OPTIONAL. Default: null. A set of `defaults` configuration.
    "defaults": {
        "true_color": {
            "assets": ["B4", "B3", "B2"],
            "color_formula": "Gamma RGB 3.5 Saturation 1.7 Sigmoidal RGB 15 0.35",
        },
        "ndvi": {
            "expression": "(B4-B3)/(B4+B3)",
            "rescale": "-1,1",
            "colormap_name": "viridis"
        }
    }
}
```