### PR TITLE
[TO BE DISCUSSED] add mosaic listing endpoint

### DIFF
--- a/titiler/pgstac/model.py
+++ b/titiler/pgstac/model.py
@@ -238,3 +238,12 @@ class Info(BaseModel):
 
     search: Search
     links: Optional[List[Link]]
+
+
+class Infos(BaseModel):
+    """Response model for /list endpoint."""
+
+    searches: List[Info]
+    links: Optional[List[Link]]
+    numberMatched: Optional[int]
+    numberReturned: Optional[int]


### PR DESCRIPTION
This PR continues the work done in #44 and adds a `/list` endpoint to list the mosaics stored in the pgstac db. By default it will only return the `search` with `metadata.type == "mosaic"` (tag added when registered the search via the `/register` endpoint.

I know @bitner raised some performance issue that could appear when there are a lot `search` in the search table 🤷‍♂️ 

IMO the `/list` endpoint could be valuable for debugging purpose or for uses who have not a lot of entries in the `search` table. I think the endpoint should not be added by default, and I'm also happy to only add this code in the documentation.


cc @sharkinsspatial