### PR TITLE
update titiler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 **breaking changes**
 
+* update `titiler.core` and `titiler.mosaic` requirement to `>=0.5`
 * When registering a `search` to PgSTAC with the `/register` endpoint, a default metadata `{"type": "mosaic"}` will be set.
 * Renamed `titiler.pgstac.models` to `titiler.pgstac.model`
 * Renamed `titiler.pgstac.models.SearchQuery` to `titiler.pgstac.model.PgSTACSearch` (and removed `metadata`)

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -135,7 +135,7 @@ Example:
     - **maxzoom**: Overwrite default maxzoom. OPTIONAL
     - **assets** (array[str]): asset names.
     - **expression** (str): rio-tiler's math expression with asset names (e.g `Asset1/Asset2`).
-    - **asset_bidx** (array[str]): Per asset band math expression (e.g `Asset1|1,2,3`).
+    - **asset_bidx** (array[str]): Per asset band indexes (e.g `Asset1|1,2,3`).
     - **asset_expression** (array[str]): Per asset band math expression (e.g `Asset1|b1\*b2`).
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ with open("README.md") as f:
     long_description = f.read()
 
 inst_reqs = [
-    "titiler.core>=0.4.0,<0.5",
-    "titiler.mosaic>=0.4.0,<0.5",
+    "titiler.core>=0.5,<0.6",
+    "titiler.mosaic>=0.5,<0.6",
     "geojson-pydantic>=0.3.1,<0.4",
     "stac-pydantic==2.0.*",
 ]


### PR DESCRIPTION
**warnings** 

TiTiler 0.5.0 use new versions of rio-tiler and morecantile,  here is the summary of the breaking changes:
- **morecantile**: new WebMercatorQuad definition to match GDAL and Mercantile definition https://github.com/developmentseed/morecantile/blob/master/CHANGES.md#310-2022-02-18
- **rio-tiler**: new Expression format using `;` instead of `,` to split bands (allow more complex numexpr expression (https://github.com/cogeotiff/rio-tiler/pull/479) 

