### PR TITLE
add single item STAC endpoints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Unreleased
+
+* move dependencies to `titiler.pgstac.dependencies`
+* add `/mosaic` prefix to the PgSTAC mosaic endpoints
+* add `/stac` endpoints to work with PgSTAC items
+
 ## 0.1.0.a5 (2022-03-03) Pre-Release
 
 * Add `search_dependency` to allow customization of the PgSTAC Search query (Author @drnextgis, https://github.com/stac-utils/titiler-pgstac/pull/41)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ---
 
-`TiTiler.PgSTAC` is a [titiler](https://github.com/developmentseed/titiler) extension which connect to [pgstac](https://github.com/stac-utils/pgstac) STAC database in order to create **mosaics** in response to a STAC-api `search` query.
+`TiTiler.PgSTAC` is a [titiler](https://github.com/developmentseed/titiler) extension which connect to [pgstac](https://github.com/stac-utils/pgstac) STAC database in order to create dynamic **mosaics** based on [`Search Query`](https://github.com/radiantearth/stac-api-spec/tree/master/item-search).
 
 ## Installation
 

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1,0 +1,50 @@
+"""Test titiler.pgstac Item endpoints."""
+
+from unittest.mock import patch
+
+import pytest
+
+from .conftest import mock_rasterio_open
+
+
+@patch("rio_tiler.io.cogeo.rasterio")
+@pytest.mark.asyncio
+async def test_stac_items(rio, app):
+    """test STAC items endpoints."""
+    rio.open = mock_rasterio_open
+
+    response = await app.get(
+        "/stac/info",
+        params={
+            "collection": "noaa-emergency-response",
+            "item": "20200307aC0853900w361030",
+        },
+    )
+    assert response.status_code == 200
+    resp = response.json()
+    assert resp["cog"]
+
+    response = await app.get(
+        "/stac/info",
+        params={
+            "collection": "noaa-emergency-response",
+            "item": "20200307aC0853900w361",
+        },
+    )
+    assert response.status_code == 404
+    assert (
+        "No item '20200307aC0853900w361' found in 'noaa-emergency-response' collection"
+        in response.json()["detail"]
+    )
+
+    response = await app.get(
+        "/stac/asset_statistics",
+        params={
+            "collection": "noaa-emergency-response",
+            "item": "20200307aC0853900w361030",
+            "assets": "cog",
+        },
+    )
+    assert response.status_code == 200
+    resp = response.json()
+    assert resp["cog"]

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -1,4 +1,4 @@
-"""Test titiler.pgstac search endpoints."""
+"""Test titiler.pgstac Mosaic endpoints."""
 
 from unittest.mock import patch
 
@@ -15,7 +15,7 @@ search_bbox = "5e86ce566b979e567370a6ad85aaa68a"
 async def test_register(app):
     """Register Search requests."""
     query = {"collections": ["noaa-emergency-response"], "filter-lang": "cql-json"}
-    response = await app.post("/register", json=query)
+    response = await app.post("/mosaic/register", json=query)
     assert response.status_code == 200
     resp = response.json()
     assert resp["searchid"] == search_no_bbox
@@ -27,7 +27,7 @@ async def test_register(app):
         "bbox": [-85.535, 36.137, -85.465, 36.179],
         "filter-lang": "cql-json",
     }
-    response = await app.post("/register", json=query)
+    response = await app.post("/mosaic/register", json=query)
     assert response.status_code == 200
 
     resp = response.json()
@@ -39,7 +39,7 @@ async def test_register(app):
 @pytest.mark.asyncio
 async def test_info(app):
     """Should return metadata about a search query."""
-    response = await app.get(f"/{search_no_bbox}/info")
+    response = await app.get(f"/mosaic/{search_no_bbox}/info")
     assert response.status_code == 200
     resp = response.json()
     assert resp["search"]
@@ -55,7 +55,7 @@ async def test_info(app):
 @pytest.mark.asyncio
 async def test_assets_for_point(app):
     """Get assets for a Point."""
-    response = await app.get(f"/{search_no_bbox}/-85.6358,36.1624/assets")
+    response = await app.get(f"/mosaic/{search_no_bbox}/-85.6358,36.1624/assets")
     assert response.status_code == 200
     resp = response.json()
     assert len(resp) == 1
@@ -63,13 +63,13 @@ async def test_assets_for_point(app):
     assert resp[0]["id"] == "20200307aC0853900w361030"
 
     # make sure we can find assets when having both bbox and geometry
-    response = await app.get(f"/{search_bbox}/-85.5,36.1624/assets")
+    response = await app.get(f"/mosaic/{search_bbox}/-85.5,36.1624/assets")
     assert response.status_code == 200
     resp = response.json()
     assert len(resp) == 2
 
     # no assets found outside the mosaic bbox
-    response = await app.get(f"/{search_bbox}/-85.6358,36.1624/assets")
+    response = await app.get(f"/mosaic/{search_bbox}/-85.6358,36.1624/assets")
     assert response.status_code == 200
     resp = response.json()
     assert len(resp) == 0
@@ -78,7 +78,7 @@ async def test_assets_for_point(app):
 @pytest.mark.asyncio
 async def test_assets_for_tile(app):
     """Get assets for a Tile."""
-    response = await app.get(f"/{search_no_bbox}/15/8589/12849/assets")
+    response = await app.get(f"/mosaic/{search_no_bbox}/15/8589/12849/assets")
     assert response.status_code == 200
     resp = response.json()
     assert len(resp) == 1
@@ -86,13 +86,13 @@ async def test_assets_for_tile(app):
     assert resp[0]["id"] == "20200307aC0853900w361030"
 
     # make sure we can find assets when having both bbox and geometry
-    response = await app.get(f"/{search_bbox}/15/8601/12849/assets")
+    response = await app.get(f"/mosaic/{search_bbox}/15/8601/12849/assets")
     assert response.status_code == 200
     resp = response.json()
     assert len(resp) == 2
 
     # no assets found outside the query bbox
-    response = await app.get(f"/{search_bbox}/15/8589/12849/assets")
+    response = await app.get(f"/mosaic/{search_bbox}/15/8589/12849/assets")
     assert response.status_code == 200
     resp = response.json()
     assert len(resp) == 0
@@ -101,10 +101,10 @@ async def test_assets_for_tile(app):
 @pytest.mark.asyncio
 async def test_tilejson(app):
     """Create TileJSON."""
-    response = await app.get(f"/{search_no_bbox}/tilejson.json")
+    response = await app.get(f"/mosaic/{search_no_bbox}/tilejson.json")
     assert response.status_code == 400
 
-    response = await app.get(f"/{search_no_bbox}/tilejson.json?assets=cog")
+    response = await app.get(f"/mosaic/{search_no_bbox}/tilejson.json?assets=cog")
     assert response.headers["content-type"] == "application/json"
     assert response.status_code == 200
     resp = response.json()
@@ -115,7 +115,7 @@ async def test_tilejson(app):
     assert "?assets=cog" in resp["tiles"][0]
 
     response = await app.get(
-        f"/{search_no_bbox}/tilejson.json?assets=cog&scan_limit=100&items_limit=1&time_limit=2&exitwhenfull=False&skipcovered=False"
+        f"/mosaic/{search_no_bbox}/tilejson.json?assets=cog&scan_limit=100&items_limit=1&time_limit=2&exitwhenfull=False&skipcovered=False"
     )
     assert response.headers["content-type"] == "application/json"
     assert response.status_code == 200
@@ -125,18 +125,18 @@ async def test_tilejson(app):
         in resp["tiles"][0]
     )
 
-    response = await app.get(f"/{search_no_bbox}/tilejson.json?expression=cog")
+    response = await app.get(f"/mosaic/{search_no_bbox}/tilejson.json?expression=cog")
     assert response.status_code == 200
     resp = response.json()
     assert "?expression=cog" in resp["tiles"][0]
 
-    response = await app.get(f"/{search_no_bbox}/tilejson.json?expression=cog")
+    response = await app.get(f"/mosaic/{search_no_bbox}/tilejson.json?expression=cog")
     assert response.status_code == 200
     resp = response.json()
     assert "?expression=cog" in resp["tiles"][0]
 
     response = await app.get(
-        f"/{search_no_bbox}/WorldCRS84Quad/tilejson.json?assets=cog"
+        f"/mosaic/{search_no_bbox}/WorldCRS84Quad/tilejson.json?assets=cog"
     )
     assert response.status_code == 200
     resp = response.json()
@@ -146,13 +146,13 @@ async def test_tilejson(app):
     assert "?assets=cog" in resp["tiles"][0]
 
     response = await app.get(
-        f"/{search_no_bbox}/tilejson.json?assets=cog&tile_format=png"
+        f"/mosaic/{search_no_bbox}/tilejson.json?assets=cog&tile_format=png"
     )
     assert response.status_code == 200
     resp = response.json()
     assert ".png?assets=cog" in resp["tiles"][0]
 
-    response = await app.get(f"/{search_bbox}/tilejson.json?assets=cog")
+    response = await app.get(f"/mosaic/{search_bbox}/tilejson.json?assets=cog")
     assert response.headers["content-type"] == "application/json"
     assert response.status_code == 200
     resp = response.json()
@@ -172,10 +172,10 @@ async def test_tiles(rio, app):
     z, x, y = 15, 8589, 12849
 
     # missing assets
-    response = await app.get(f"/tiles/{search_no_bbox}/{z}/{x}/{y}")
+    response = await app.get(f"/mosaic/tiles/{search_no_bbox}/{z}/{x}/{y}")
     assert response.status_code == 400
 
-    response = await app.get(f"/tiles/{search_no_bbox}/{z}/{x}/{y}?assets=cog")
+    response = await app.get(f"/mosaic/tiles/{search_no_bbox}/{z}/{x}/{y}?assets=cog")
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/jpeg"
     meta = parse_img(response.content)
@@ -183,7 +183,7 @@ async def test_tiles(rio, app):
     assert meta["height"] == 256
 
     response = await app.get(
-        f"/tiles/{search_no_bbox}/{z}/{x}/{y}?assets=cog&buffer=0.5"
+        f"/mosaic/tiles/{search_no_bbox}/{z}/{x}/{y}?assets=cog&buffer=0.5"
     )
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/jpeg"
@@ -191,7 +191,9 @@ async def test_tiles(rio, app):
     assert meta["width"] == 257
     assert meta["height"] == 257
 
-    response = await app.get(f"/tiles/{search_no_bbox}/{z}/{x}/{y}.png?assets=cog")
+    response = await app.get(
+        f"/mosaic/tiles/{search_no_bbox}/{z}/{x}/{y}.png?assets=cog"
+    )
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/png"
     meta = parse_img(response.content)
@@ -199,11 +201,11 @@ async def test_tiles(rio, app):
     assert meta["height"] == 256
 
     # tile is outside mosaic bbox, it should return 404 (NoAssetFoundError)
-    response = await app.get(f"/tiles/{search_bbox}/{z}/{x}/{y}?assets=cog")
+    response = await app.get(f"/mosaic/tiles/{search_bbox}/{z}/{x}/{y}?assets=cog")
     assert response.status_code == 404
 
     response = await app.get(
-        f"/tiles/{search_no_bbox}/WebMercatorQuad/{z}/{x}/{y}.tif?assets=cog"
+        f"/mosaic/tiles/{search_no_bbox}/WebMercatorQuad/{z}/{x}/{y}.tif?assets=cog"
     )
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/tiff; application=geotiff"
@@ -213,7 +215,7 @@ async def test_tiles(rio, app):
     assert meta["height"] == 256
 
     response = await app.get(
-        f"/tiles/{search_no_bbox}/WorldCRS84Quad/18/137421/78424.tif?assets=cog"
+        f"/mosaic/tiles/{search_no_bbox}/WorldCRS84Quad/18/137421/78424.tif?assets=cog"
     )
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/tiff; application=geotiff"
@@ -235,7 +237,7 @@ async def test_cql2(rio, app):
             "args": [{"property": "collection"}, "noaa-emergency-response"],
         }
     }
-    response = await app.post("/register", json=query)
+    response = await app.post("/mosaic/register", json=query)
     assert response.status_code == 200
     resp = response.json()
     assert resp["searchid"]
@@ -243,7 +245,7 @@ async def test_cql2(rio, app):
 
     cql2_id = resp["searchid"]
 
-    response = await app.get(f"/{cql2_id}/info")
+    response = await app.get(f"/mosaic/{cql2_id}/info")
     assert response.status_code == 200
     resp = response.json()
     assert resp["search"]
@@ -257,21 +259,21 @@ async def test_cql2(rio, app):
     }
     assert search["metadata"] == {"type": "mosaic"}
 
-    response = await app.get(f"/{cql2_id}/-85.6358,36.1624/assets")
+    response = await app.get(f"/mosaic/{cql2_id}/-85.6358,36.1624/assets")
     assert response.status_code == 200
     resp = response.json()
     assert len(resp) == 1
     assert list(resp[0]) == ["id", "bbox", "assets"]
     assert resp[0]["id"] == "20200307aC0853900w361030"
 
-    response = await app.get(f"/{cql2_id}/15/8589/12849/assets")
+    response = await app.get(f"/mosaic/{cql2_id}/15/8589/12849/assets")
     assert response.status_code == 200
     resp = response.json()
     assert len(resp) == 1
     assert list(resp[0]) == ["id", "bbox", "assets"]
     assert resp[0]["id"] == "20200307aC0853900w361030"
 
-    response = await app.get(f"/{cql2_id}/tilejson.json?assets=cog")
+    response = await app.get(f"/mosaic/{cql2_id}/tilejson.json?assets=cog")
     assert response.headers["content-type"] == "application/json"
     assert response.status_code == 200
     resp = response.json()
@@ -282,7 +284,7 @@ async def test_cql2(rio, app):
     assert "?assets=cog" in resp["tiles"][0]
 
     z, x, y = 15, 8589, 12849
-    response = await app.get(f"/tiles/{cql2_id}/{z}/{x}/{y}?assets=cog")
+    response = await app.get(f"/mosaic/tiles/{cql2_id}/{z}/{x}/{y}?assets=cog")
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/jpeg"
     meta = parse_img(response.content)
@@ -325,7 +327,7 @@ async def test_cql2_with_geometry(rio, app):
             ],
         }
     }
-    response = await app.post("/register", json=query)
+    response = await app.post("/mosaic/register", json=query)
     assert response.status_code == 200
     resp = response.json()
     assert resp["searchid"]
@@ -333,7 +335,7 @@ async def test_cql2_with_geometry(rio, app):
 
     cql2_id = resp["searchid"]
 
-    response = await app.get(f"/{cql2_id}/info")
+    response = await app.get(f"/mosaic/{cql2_id}/info")
     assert response.status_code == 200
     resp = response.json()
     assert resp["search"]
@@ -342,32 +344,32 @@ async def test_cql2_with_geometry(rio, app):
     assert search["metadata"] == {"type": "mosaic"}
 
     # make sure we can find assets when having both geometry filter and geometry
-    response = await app.get(f"/{cql2_id}/15/8601/12849/assets")
+    response = await app.get(f"/mosaic/{cql2_id}/15/8601/12849/assets")
     assert response.status_code == 200
     resp = response.json()
     assert len(resp) == 2
 
     # point is outside the geometry filter
-    response = await app.get(f"/{cql2_id}/-85.6358,36.1624/assets")
+    response = await app.get(f"/mosaic/{cql2_id}/-85.6358,36.1624/assets")
     assert response.status_code == 200
     resp = response.json()
     assert len(resp) == 0
 
     # make sure we can find assets when having both geometry filter and geometry
-    response = await app.get(f"/{cql2_id}/15/8601/12849/assets")
+    response = await app.get(f"/mosaic/{cql2_id}/15/8601/12849/assets")
     assert response.status_code == 200
     resp = response.json()
     assert len(resp) == 2
 
     # tile is outside the geometry filter
-    response = await app.get(f"/{cql2_id}/15/8589/12849/assets")
+    response = await app.get(f"/mosaic/{cql2_id}/15/8589/12849/assets")
     assert response.status_code == 200
     resp = response.json()
     assert len(resp) == 0
 
     # tile is outside the geometry filter
     z, x, y = 15, 8589, 12849
-    response = await app.get(f"/tiles/{cql2_id}/{z}/{x}/{y}?assets=cog")
+    response = await app.get(f"/mosaic/tiles/{cql2_id}/{z}/{x}/{y}?assets=cog")
     assert response.status_code == 404
 
 
@@ -382,7 +384,7 @@ async def test_query_with_metadata(app):
         "metadata": {"name": "mymosaic", "minzoom": 1, "maxzoom": 2},
     }
 
-    response = await app.post("/register", json=query)
+    response = await app.post("/mosaic/register", json=query)
     assert response.status_code == 200
     resp = response.json()
     assert resp["searchid"]
@@ -390,7 +392,7 @@ async def test_query_with_metadata(app):
 
     cql2_id = resp["searchid"]
 
-    response = await app.get(f"/{cql2_id}/info")
+    response = await app.get(f"/mosaic/{cql2_id}/info")
     assert response.status_code == 200
     resp = response.json()
     assert resp["search"]

--- a/titiler/pgstac/dependencies.py
+++ b/titiler/pgstac/dependencies.py
@@ -1,0 +1,100 @@
+"""titiler-pgstac dependencies."""
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+import pystac
+from cachetools import TTLCache, cached
+from cachetools.keys import hashkey
+from psycopg.rows import dict_row
+from psycopg_pool import ConnectionPool
+
+from titiler.core.dependencies import DefaultDependency
+from titiler.pgstac import model
+
+from fastapi import HTTPException, Path, Query
+
+from starlette.requests import Request
+
+
+def PathParams(searchid: str = Path(..., description="Search Id")) -> str:
+    """SearcId"""
+    return searchid
+
+
+def SearchParams(
+    body: model.RegisterMosaic,
+) -> Tuple[model.PgSTACSearch, model.Metadata]:
+    """Search parameters."""
+    search = body.dict(
+        exclude_none=True,
+        exclude={"metadata"},
+        by_alias=True,
+    )
+    return model.PgSTACSearch(**search), body.metadata
+
+
+@dataclass
+class PgSTACParams(DefaultDependency):
+    """PgSTAC parameters."""
+
+    scan_limit: Optional[int] = Query(
+        None,
+        description="Return as soon as we scan N items (defaults to 10000 in PgSTAC).",
+    )
+    items_limit: Optional[int] = Query(
+        None,
+        description="Return as soon as we have N items per geometry (defaults to 100 in PgSTAC).",
+    )
+    time_limit: Optional[int] = Query(
+        None,
+        description="Return after N seconds to avoid long requests (defaults to 5 in PgSTAC).",
+    )
+    exitwhenfull: Optional[bool] = Query(
+        None,
+        description="Return as soon as the geometry is fully covered (defaults to True in PgSTAC).",
+    )
+    skipcovered: Optional[bool] = Query(
+        None,
+        description="Skip any items that would show up completely under the previous items (defaults to True in PgSTAC).",
+    )
+
+
+@cached(
+    TTLCache(
+        maxsize=512, ttl=300
+    ),  # TODO: make this configurable. see https://github.com/developmentseed/cogeo-mosaic/blob/master/cogeo_mosaic/cache.py#L6-L32
+    key=lambda pool, collection, item: hashkey(collection, item),
+)
+def get_stac_item(pool: ConnectionPool, collection: str, item: str) -> Dict:
+    """Get STAC Item from PGStac."""
+    with pool.connection() as conn:
+        with conn.cursor(row_factory=dict_row) as cursor:
+            cursor.execute(
+                (
+                    "SELECT * FROM pgstac.items WHERE "
+                    "collection_id=%s AND id=%s LIMIT 1;"
+                ),
+                (
+                    collection,
+                    item,
+                ),
+            )
+
+            resp = cursor.fetchone()
+            if not resp:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"No item '{item}' found in '{collection}' collection",
+                )
+
+            return pystac.Item.from_dict(resp["content"])
+
+
+def ItemPathParams(
+    request: Request,
+    collection: str = Query(..., description="STAC Collection ID"),
+    item: str = Query(..., description="STAC Item ID"),
+) -> Dict:
+    """STAC Item dependency."""
+    return get_stac_item(request.app.state.dbpool, collection, item)

--- a/titiler/pgstac/factory.py
+++ b/titiler/pgstac/factory.py
@@ -18,55 +18,13 @@ from titiler.core.resources.enums import ImageType, OptionalHeader
 from titiler.core.utils import Timer
 from titiler.mosaic.resources.enums import PixelSelectionMethod
 from titiler.pgstac import model
+from titiler.pgstac.dependencies import PathParams, PgSTACParams, SearchParams
 from titiler.pgstac.mosaic import PGSTACBackend
 
 from fastapi import Depends, Path, Query
 
 from starlette.requests import Request
 from starlette.responses import Response
-
-
-def PathParams(searchid: str = Path(..., description="Search Id")) -> str:
-    """SearcId"""
-    return searchid
-
-
-def SearchParams(
-    body: model.RegisterMosaic,
-) -> Tuple[model.PgSTACSearch, model.Metadata]:
-    """Search parameters."""
-    search = body.dict(
-        exclude_none=True,
-        exclude={"metadata"},
-        by_alias=True,
-    )
-    return model.PgSTACSearch(**search), body.metadata
-
-
-@dataclass
-class PgSTACParams(DefaultDependency):
-    """PgSTAC parameters."""
-
-    scan_limit: Optional[int] = Query(
-        None,
-        description="Return as soon as we scan N items (defaults to 10000 in PgSTAC).",
-    )
-    items_limit: Optional[int] = Query(
-        None,
-        description="Return as soon as we have N items per geometry (defaults to 100 in PgSTAC).",
-    )
-    time_limit: Optional[int] = Query(
-        None,
-        description="Return after N seconds to avoid long requests (defaults to 5 in PgSTAC).",
-    )
-    exitwhenfull: Optional[bool] = Query(
-        None,
-        description="Return as soon as the geometry is fully covered (defaults to True in PgSTAC).",
-    )
-    skipcovered: Optional[bool] = Query(
-        None,
-        description="Skip any items that would show up completely under the previous items (defaults to True in PgSTAC).",
-    )
 
 
 @dataclass

--- a/titiler/pgstac/reader.py
+++ b/titiler/pgstac/reader.py
@@ -16,7 +16,6 @@ from rio_tiler.io.stac import DEFAULT_VALID_TYPE, _get_assets
 class PgSTACReader(MultiBaseReader):
     """Custom STAC Reader."""
 
-    # Input can be of type String or Dict
     input: pystac.Item = attr.ib()
 
     tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)

--- a/titiler/pgstac/reader.py
+++ b/titiler/pgstac/reader.py
@@ -1,0 +1,75 @@
+"""Custom STAC reader."""
+
+from typing import Dict, Optional, Set, Type
+
+import attr
+import pystac
+from morecantile import TileMatrixSet
+from rasterio.crs import CRS
+from rio_tiler.constants import WEB_MERCATOR_TMS, WGS84_CRS
+from rio_tiler.errors import InvalidAssetName, MissingAssets
+from rio_tiler.io import BaseReader, COGReader, MultiBaseReader
+from rio_tiler.io.stac import DEFAULT_VALID_TYPE, _get_assets
+
+
+@attr.s
+class PgSTACReader(MultiBaseReader):
+    """Custom STAC Reader."""
+
+    # Input can be of type String or Dict
+    input: pystac.Item = attr.ib()
+
+    tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
+    minzoom: int = attr.ib(default=None)
+    maxzoom: int = attr.ib(default=None)
+
+    geographic_crs: CRS = attr.ib(default=WGS84_CRS)
+
+    include_assets: Optional[Set[str]] = attr.ib(default=None)
+    exclude_assets: Optional[Set[str]] = attr.ib(default=None)
+
+    include_asset_types: Set[str] = attr.ib(default=DEFAULT_VALID_TYPE)
+    exclude_asset_types: Optional[Set[str]] = attr.ib(default=None)
+
+    reader: Type[BaseReader] = attr.ib(default=COGReader)
+    reader_options: Dict = attr.ib(factory=dict)
+
+    fetch_options: Dict = attr.ib(factory=dict)
+
+    def __attrs_post_init__(self):
+        """Fetch STAC Item and get list of valid assets."""
+        self.bounds = self.input.bbox
+        self.crs = WGS84_CRS
+
+        self.assets = list(
+            _get_assets(
+                self.input,
+                include=self.include_assets,
+                exclude=self.exclude_assets,
+                include_asset_types=self.include_asset_types,
+                exclude_asset_types=self.exclude_asset_types,
+            )
+        )
+        if not self.assets:
+            raise MissingAssets("No valid asset found")
+
+        if self.minzoom is None:
+            self.minzoom = self.tms.minzoom
+
+        if self.maxzoom is None:
+            self.maxzoom = self.tms.maxzoom
+
+    def _get_asset_url(self, asset: str) -> str:
+        """Validate asset names and return asset's url.
+
+        Args:
+            asset (str): STAC asset name.
+
+        Returns:
+            str: STAC asset href.
+
+        """
+        if asset not in self.assets:
+            raise InvalidAssetName(f"{asset} is not valid")
+
+        return self.input.assets[asset].get_absolute_href()


### PR DESCRIPTION
This PR adds a set of endpoints for single STAC items with `/stac` prefix. Item must be designed with `?item={item id}&collection={collection id}` query parameter. 

ref: https://github.com/microsoft/planetary-computer-apis/pull/55

**breaking change** 
* add `/mosaic` prefix to PgSTAC mosaic endpoints

cc @mmcfarland @lossyrob @moradology