### PR TITLE
Insert mosaic metadata `min/max zoom` and `bounds` in tilejson

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+
+* Insert mosaic metadata `min/max zoom` and `bounds` in tilejson
+
 ## 0.1.0.a7 (2022-04-05) Pre-Release
 
 * add `feature()` method to `PGSTACBackend` mosaic backend

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -411,6 +411,12 @@ async def test_query_with_metadata(app):
         "maxzoom": 2,
     }
 
+    response = await app.get(f"/mosaic/{cql2_id}/tilejson.json?assets=cog")
+    assert response.status_code == 200
+    resp = response.json()
+    assert resp["minzoom"] == 1
+    assert resp["maxzoom"] == 2
+
 
 @patch("rio_tiler.io.cogeo.rasterio")
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR does:

Forward mosaic metadata name, zooms and bounds to the tilejson document 