### PR TITLE
Support providing postgres settings via argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Insert mosaic metadata `min/max zoom` and `bounds` in tilejson
-* allow users the ability to optionally provide `PostgresSettings` to `connect_to_db()` function in the event that they want to customize how their DB credentials are populated (https://github.com/stac-utils/titiler-pgstac/pull/53)
+* allow users the ability to optionally provide `PostgresSettings` to `connect_to_db()` function in the event that they want to customize how their DB credentials are populated (author @alukach, https://github.com/stac-utils/titiler-pgstac/pull/53)
 
 
 ## 0.1.0.a7 (2022-04-05) Pre-Release

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 * Insert mosaic metadata `min/max zoom` and `bounds` in tilejson
+* allow users the ability to optionally provide `PostgresSettings` to `connect_to_db()` function in the event that they want to customize how their DB credentials populated (https://github.com/stac-utils/titiler-pgstac/pull/53)
+
 
 ## 0.1.0.a7 (2022-04-05) Pre-Release
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Insert mosaic metadata `min/max zoom` and `bounds` in tilejson
-* allow users the ability to optionally provide `PostgresSettings` to `connect_to_db()` function in the event that they want to customize how their DB credentials populated (https://github.com/stac-utils/titiler-pgstac/pull/53)
+* allow users the ability to optionally provide `PostgresSettings` to `connect_to_db()` function in the event that they want to customize how their DB credentials are populated (https://github.com/stac-utils/titiler-pgstac/pull/53)
 
 
 ## 0.1.0.a7 (2022-04-05) Pre-Release

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,7 +124,7 @@ async def app():
 
             await conn.close()
 
-            await connect_to_db(app)
+            await connect_to_db(app, settings)
             async with AsyncClient(app=app, base_url="http://test") as client:
                 yield client
             await close_db_connection(app)

--- a/titiler/pgstac/db.py
+++ b/titiler/pgstac/db.py
@@ -7,8 +7,10 @@ from titiler.pgstac.settings import PostgresSettings
 from fastapi import FastAPI
 
 
-async def connect_to_db(app: FastAPI, settings: PostgresSettings) -> None:
+async def connect_to_db(app: FastAPI, settings: PostgresSettings = None) -> None:
     """Connect to Database."""
+    if not settings:
+        settings = PostgresSettings()
     app.state.dbpool = ConnectionPool(
         conninfo=settings.connection_string,
         min_size=settings.db_min_conn_size,

--- a/titiler/pgstac/db.py
+++ b/titiler/pgstac/db.py
@@ -6,10 +6,8 @@ from titiler.pgstac.settings import PostgresSettings
 
 from fastapi import FastAPI
 
-settings = PostgresSettings()
 
-
-async def connect_to_db(app: FastAPI) -> None:
+async def connect_to_db(app: FastAPI, settings: PostgresSettings) -> None:
     """Connect to Database."""
     app.state.dbpool = ConnectionPool(
         conninfo=settings.connection_string,

--- a/titiler/pgstac/db.py
+++ b/titiler/pgstac/db.py
@@ -1,5 +1,7 @@
 """Database connection handling."""
 
+from typing import Optional
+
 from psycopg_pool import ConnectionPool
 
 from titiler.pgstac.settings import PostgresSettings
@@ -7,10 +9,13 @@ from titiler.pgstac.settings import PostgresSettings
 from fastapi import FastAPI
 
 
-async def connect_to_db(app: FastAPI, settings: PostgresSettings = None) -> None:
+async def connect_to_db(
+    app: FastAPI, settings: Optional[PostgresSettings] = None
+) -> None:
     """Connect to Database."""
     if not settings:
         settings = PostgresSettings()
+
     app.state.dbpool = ConnectionPool(
         conninfo=settings.connection_string,
         min_size=settings.db_min_conn_size,

--- a/titiler/pgstac/main.py
+++ b/titiler/pgstac/main.py
@@ -17,7 +17,7 @@ from titiler.pgstac.db import close_db_connection, connect_to_db
 from titiler.pgstac.dependencies import ItemPathParams
 from titiler.pgstac.factory import MosaicTilerFactory
 from titiler.pgstac.reader import PgSTACReader
-from titiler.pgstac.settings import ApiSettings, PostgresSettings
+from titiler.pgstac.settings import ApiSettings
 from titiler.pgstac.version import __version__ as titiler_pgstac_version
 
 from fastapi import FastAPI
@@ -29,7 +29,6 @@ logging.getLogger("botocore.utils").disabled = True
 logging.getLogger("rio-tiler").setLevel(logging.ERROR)
 
 settings = ApiSettings()
-pg_settings = PostgresSettings()
 
 app = FastAPI(title=settings.name, version=titiler_pgstac_version)
 
@@ -37,7 +36,7 @@ app = FastAPI(title=settings.name, version=titiler_pgstac_version)
 @app.on_event("startup")
 async def startup_event() -> None:
     """Connect to database on startup."""
-    await connect_to_db(app, settings=pg_settings)
+    await connect_to_db(app)
 
 
 @app.on_event("shutdown")

--- a/titiler/pgstac/main.py
+++ b/titiler/pgstac/main.py
@@ -17,7 +17,7 @@ from titiler.pgstac.db import close_db_connection, connect_to_db
 from titiler.pgstac.dependencies import ItemPathParams
 from titiler.pgstac.factory import MosaicTilerFactory
 from titiler.pgstac.reader import PgSTACReader
-from titiler.pgstac.settings import ApiSettings
+from titiler.pgstac.settings import ApiSettings, PostgresSettings
 from titiler.pgstac.version import __version__ as titiler_pgstac_version
 
 from fastapi import FastAPI
@@ -29,6 +29,7 @@ logging.getLogger("botocore.utils").disabled = True
 logging.getLogger("rio-tiler").setLevel(logging.ERROR)
 
 settings = ApiSettings()
+pg_settings = PostgresSettings()
 
 app = FastAPI(title=settings.name, version=titiler_pgstac_version)
 
@@ -36,7 +37,7 @@ app = FastAPI(title=settings.name, version=titiler_pgstac_version)
 @app.on_event("startup")
 async def startup_event() -> None:
     """Connect to database on startup."""
-    await connect_to_db(app)
+    await connect_to_db(app, settings=pg_settings)
 
 
 @app.on_event("shutdown")


### PR DESCRIPTION
Currently, this codebase expects that the postgres configuration be available via environment variables.  However, there are situations in which a user might not have these configurations available in the runtime environment.  For example, a user might want their application to be responsive to DB credential changes without redeployment so they fetch credentials at Lambda startup from AWS Secrets Manager.

This PR reworks the `connect_to_db()` to take the `PostgresSettings` instance as an argument (ie Inversion of Control).  This makes it easier for systems that depend on extending this codebase to customize how they generate settings.

/cc @anayeaye