### PR TITLE
Give better error if the search ID is not found when using the info endpoint

### DIFF
--- a/titiler/pgstac/factory.py
+++ b/titiler/pgstac/factory.py
@@ -400,6 +400,9 @@ class MosaicTilerFactory(BaseTilerFactory):
                     )
                     search_info = cursor.fetchone()
 
+            if not search_info:
+                raise KeyError(f"search {searchid} not found")
+
             return model.Info(
                 search=search_info,
                 links=[


### PR DESCRIPTION
This is a tiny PR to improve the error message given when a search_id isn't found when accessing the `/mosaic/{search_id}/info` endpoint.

Previously the error was:

```
{
"detail": "'NoneType' object has no attribute 'id'"
}
```

Now it is:

```
{
"detail": "'search blah not found'"
}
```

(error message copied from elsewhere)