### PR TITLE
add retry mechanism

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.2.4 (2023-04-27)
+
+* add retry mechanism on Database connection issues for `PGSTACBackend.get_assets()` and `get_stac_item` methods
+
 ## 0.2.3 (2023-03-14)
 
 * fix maximum version of FastAPI to 0.92 (to avoid breaking change of starlette >0.25)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
   database:
     container_name: stac-db
     platform: linux/amd64
-    image: ghcr.io/stac-utils/pgstac:v0.6.11
+    image: ghcr.io/stac-utils/pgstac:v0.7.4
     environment:
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password

--- a/titiler/pgstac/db.py
+++ b/titiler/pgstac/db.py
@@ -1,10 +1,14 @@
 """Database connection handling."""
 
-from typing import Optional
+import time
+from contextlib import contextmanager
+from typing import Any, Generator, List, Optional, Type, Union
 
+import psycopg
 from fastapi import FastAPI
 from psycopg_pool import ConnectionPool
 
+from titiler.pgstac.logger import logger
 from titiler.pgstac.settings import PostgresSettings
 
 
@@ -29,3 +33,47 @@ async def connect_to_db(
 async def close_db_connection(app: FastAPI) -> None:
     """Close Pool."""
     app.state.dbpool.close()
+
+
+def retry(
+    tries: int,
+    exceptions: Union[Type[Exception], List[Type[Exception]]] = Exception,
+    delay: int = 0,
+):
+    """Retry Decorator"""
+
+    def _decorator(func: Any):
+        def _newfn(*args: Any, **kwargs: Any):
+
+            attempt = 0
+            while attempt < tries:
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as e:  # type: ignore
+                    logger.debug(repr(e))
+                    logger.warning(f"Retrying `{func}` | Attempt {attempt}")
+
+                    attempt += 1
+                    time.sleep(delay)
+
+            return func(*args, **kwargs)
+
+        return _newfn
+
+    return _decorator
+
+
+@retry(tries=3, exceptions=psycopg.OperationalError)
+@contextmanager
+def execute_query(
+    pool: ConnectionPool,
+    *,
+    query: psycopg.abc.Query,
+    params: Optional[psycopg.abc.Params] = None,
+    row_factory: Optional[psycopg.rows.RowFactory[psycopg.rows.Row]] = None,
+) -> Generator[psycopg.Cursor, None, None]:
+    """Get Connection and Execute Query."""
+    with pool.connection() as conn:
+        with conn.cursor(row_factory=row_factory) as cursor:
+            cursor.execute(query, params=params)
+            yield cursor

--- a/titiler/pgstac/db.py
+++ b/titiler/pgstac/db.py
@@ -1,14 +1,10 @@
 """Database connection handling."""
 
-import time
-from contextlib import contextmanager
-from typing import Any, Generator, List, Optional, Type, Union
+from typing import Optional
 
-import psycopg
 from fastapi import FastAPI
 from psycopg_pool import ConnectionPool
 
-from titiler.pgstac.logger import logger
 from titiler.pgstac.settings import PostgresSettings
 
 
@@ -33,47 +29,3 @@ async def connect_to_db(
 async def close_db_connection(app: FastAPI) -> None:
     """Close Pool."""
     app.state.dbpool.close()
-
-
-def retry(
-    tries: int,
-    exceptions: Union[Type[Exception], List[Type[Exception]]] = Exception,
-    delay: int = 0,
-):
-    """Retry Decorator"""
-
-    def _decorator(func: Any):
-        def _newfn(*args: Any, **kwargs: Any):
-
-            attempt = 0
-            while attempt < tries:
-                try:
-                    return func(*args, **kwargs)
-                except exceptions as e:  # type: ignore
-                    logger.debug(repr(e))
-                    logger.warning(f"Retrying `{func}` | Attempt {attempt}")
-
-                    attempt += 1
-                    time.sleep(delay)
-
-            return func(*args, **kwargs)
-
-        return _newfn
-
-    return _decorator
-
-
-@retry(tries=3, exceptions=psycopg.OperationalError)
-@contextmanager
-def execute_query(
-    pool: ConnectionPool,
-    *,
-    query: psycopg.abc.Query,
-    params: Optional[psycopg.abc.Params] = None,
-    row_factory: Optional[psycopg.rows.RowFactory[psycopg.rows.Row]] = None,
-) -> Generator[psycopg.Cursor, None, None]:
-    """Get Connection and Execute Query."""
-    with pool.connection() as conn:
-        with conn.cursor(row_factory=row_factory) as cursor:
-            cursor.execute(query, params=params)
-            yield cursor

--- a/titiler/pgstac/dependencies.py
+++ b/titiler/pgstac/dependencies.py
@@ -18,7 +18,7 @@ from titiler.pgstac.settings import CacheSettings, RetrySettings
 from titiler.pgstac.utils import retry
 
 cache_config = CacheSettings()
-retry_setting = RetrySettings()
+retry_config = RetrySettings()
 
 
 def PathParams(searchid: str = Path(..., description="Search Id")) -> str:
@@ -84,8 +84,8 @@ class PgSTACParams(DefaultDependency):
     key=lambda pool, collection, item: hashkey(collection, item),
 )
 @retry(
-    tries=retry_setting.retry,
-    delay=retry_setting.delay,
+    tries=retry_config.retry,
+    delay=retry_config.delay,
     exceptions=(
         pgErrors.OperationalError,
         pgErrors.InterfaceError,

--- a/titiler/pgstac/logger.py
+++ b/titiler/pgstac/logger.py
@@ -1,0 +1,5 @@
+"""titiler-pgstac logger."""
+
+import logging
+
+logger = logging.getLogger("titiler-pgstac")

--- a/titiler/pgstac/mosaic.py
+++ b/titiler/pgstac/mosaic.py
@@ -27,7 +27,6 @@ from rio_tiler.mosaic import mosaic_reader
 from rio_tiler.tasks import multi_values
 from rio_tiler.types import AssetInfo, BBox
 
-# from titiler.pgstac.db import ExecuteOrRetry
 from titiler.pgstac.settings import CacheSettings, RetrySettings
 from titiler.pgstac.utils import retry
 

--- a/titiler/pgstac/mosaic.py
+++ b/titiler/pgstac/mosaic.py
@@ -27,6 +27,7 @@ from rio_tiler.mosaic import mosaic_reader
 from rio_tiler.tasks import multi_values
 from rio_tiler.types import AssetInfo, BBox
 
+from titiler.pgstac.db import execute_query
 from titiler.pgstac.settings import CacheSettings
 
 cache_config = CacheSettings()
@@ -212,32 +213,29 @@ class PGSTACBackend(BaseBackend):
         exitwhenfull = True if exitwhenfull is None else exitwhenfull
         skipcovered = True if skipcovered is None else skipcovered
 
-        with self.pool.connection() as conn:
-            with conn.cursor() as cursor:
-                try:
-                    cursor.execute(
-                        "SELECT * FROM geojsonsearch(%s, %s, %s, %s, %s, %s, %s, %s);",
-                        (
-                            geom.json(exclude_none=True),
-                            self.input,
-                            json.dumps(fields),
-                            scan_limit,
-                            items_limit,
-                            f"{time_limit} seconds",
-                            exitwhenfull,
-                            skipcovered,
-                        ),
-                    )
-                except pgErrors.RaiseException as e:
-                    # Catch Invalid SearchId and raise specific Error
-                    if f"Search with Query Hash {self.input} Not Found" in str(e):
-                        raise MosaicNotFoundError(
-                            f"SearchId `{self.input}` not found"
-                        ) from e
-                    else:
-                        raise e
-
+        try:
+            with execute_query(
+                self.pool,
+                query="SELECT * FROM geojsonsearch(%s, %s, %s, %s, %s, %s, %s, %s);",
+                params=(
+                    geom.json(exclude_none=True),
+                    self.input,
+                    json.dumps(fields),
+                    scan_limit,
+                    items_limit,
+                    f"{time_limit} seconds",
+                    exitwhenfull,
+                    skipcovered,
+                ),
+            ) as cursor:
                 resp = cursor.fetchone()[0]
+
+        except pgErrors.ProgrammingError as e:
+            # Catch Invalid SearchId and raise specific Error
+            if f"Search with Query Hash {self.input} Not Found" in str(e):
+                raise MosaicNotFoundError(f"SearchId `{self.input}` not found") from e
+            else:
+                raise e
 
         return resp.get("features", [])
 

--- a/titiler/pgstac/mosaic.py
+++ b/titiler/pgstac/mosaic.py
@@ -30,8 +30,8 @@ from rio_tiler.types import AssetInfo, BBox
 from titiler.pgstac.settings import CacheSettings, RetrySettings
 from titiler.pgstac.utils import retry
 
-retry_setting = RetrySettings()
 cache_config = CacheSettings()
+retry_config = RetrySettings()
 
 
 @attr.s
@@ -194,8 +194,8 @@ class PGSTACBackend(BaseBackend):
         key=lambda self, geom, **kwargs: hashkey(self.input, str(geom), **kwargs),
     )
     @retry(
-        tries=retry_setting.retry,
-        delay=retry_setting.delay,
+        tries=retry_config.retry,
+        delay=retry_config.delay,
         exceptions=(
             pgErrors.OperationalError,
             pgErrors.InterfaceError,

--- a/titiler/pgstac/settings.py
+++ b/titiler/pgstac/settings.py
@@ -3,7 +3,14 @@
 from functools import lru_cache
 from typing import Any, Dict, Optional
 
-from pydantic import BaseSettings, PostgresDsn, conint, root_validator, validator
+from pydantic import (
+    BaseSettings,
+    PostgresDsn,
+    confloat,
+    conint,
+    root_validator,
+    validator,
+)
 
 
 class ApiSettings(BaseSettings):
@@ -108,7 +115,7 @@ class _RetrySettings(BaseSettings):
     """Retry settings"""
 
     retry: conint(ge=0) = 3  # type: ignore[valid-type]
-    delay: conint(ge=0) = 0  # type: ignore[valid-type]
+    delay: confloat(ge=0) = 0.0  # type: ignore[valid-type]
 
     class Config:
         """model config"""

--- a/titiler/pgstac/settings.py
+++ b/titiler/pgstac/settings.py
@@ -1,11 +1,12 @@
 """API settings."""
 
+from functools import lru_cache
 from typing import Any, Dict, Optional
 
-import pydantic
+from pydantic import BaseSettings, PostgresDsn, conint, root_validator, validator
 
 
-class ApiSettings(pydantic.BaseSettings):
+class ApiSettings(BaseSettings):
     """API settings"""
 
     name: str = "titiler-pgstac"
@@ -13,7 +14,7 @@ class ApiSettings(pydantic.BaseSettings):
     cachecontrol: str = "public, max-age=3600"
     debug: bool = False
 
-    @pydantic.validator("cors_origins")
+    @validator("cors_origins")
     def parse_cors_origin(cls, v):
         """Parse CORS origins."""
         return [origin.strip() for origin in v.split(",")]
@@ -25,7 +26,7 @@ class ApiSettings(pydantic.BaseSettings):
         env_file = ".env"
 
 
-class PostgresSettings(pydantic.BaseSettings):
+class PostgresSettings(BaseSettings):
     """Postgres-specific API settings.
 
     Attributes:
@@ -42,7 +43,7 @@ class PostgresSettings(pydantic.BaseSettings):
     postgres_port: Optional[str]
     postgres_dbname: Optional[str]
 
-    database_url: Optional[pydantic.PostgresDsn] = None
+    database_url: Optional[PostgresDsn] = None
 
     # see https://www.psycopg.org/psycopg3/docs/api/pool.html#the-connectionpool-class for options
     db_min_conn_size: int = 1  # The minimum number of connection the pool will hold
@@ -60,13 +61,13 @@ class PostgresSettings(pydantic.BaseSettings):
 
         env_file = ".env"
 
-    @pydantic.validator("database_url", pre=True)
+    @validator("database_url", pre=True)
     def assemble_db_connection(cls, v: Optional[str], values: Dict[str, Any]) -> Any:
         """Validate database config."""
         if isinstance(v, str):
             return v
 
-        return pydantic.PostgresDsn.build(
+        return PostgresDsn.build(
             scheme="postgresql",
             user=values.get("postgres_user"),
             password=values.get("postgres_pass"),
@@ -76,7 +77,7 @@ class PostgresSettings(pydantic.BaseSettings):
         )
 
 
-class CacheSettings(pydantic.BaseSettings):
+class CacheSettings(BaseSettings):
     """Cache settings"""
 
     # TTL of the cache in seconds
@@ -94,10 +95,29 @@ class CacheSettings(pydantic.BaseSettings):
         env_prefix = "TITILER_PGSTAC_CACHE_"
         env_file = ".env"
 
-    @pydantic.root_validator
+    @root_validator
     def check_enable(cls, values):
         """Check if cache is desabled."""
         if values.get("disable"):
             values["ttl"] = 0
             values["maxsize"] = 0
         return values
+
+
+class _RetrySettings(BaseSettings):
+    """Retry settings"""
+
+    retry: conint(ge=0) = 3  # type: ignore[valid-type]
+    delay: conint(ge=0) = 0  # type: ignore[valid-type]
+
+    class Config:
+        """model config"""
+
+        env_prefix = "TITILER_PGSTAC_API_"
+        env_file = ".env"
+
+
+@lru_cache()
+def RetrySettings() -> _RetrySettings:
+    """This function returns a cached instance of the RetrySettings object."""
+    return _RetrySettings()

--- a/titiler/pgstac/utils.py
+++ b/titiler/pgstac/utils.py
@@ -1,0 +1,34 @@
+"""titiler.pgstac utilities."""
+
+import time
+from typing import Any, List, Type, Union
+
+from titiler.pgstac.logger import logger
+
+
+def retry(
+    tries: int,
+    exceptions: Union[Type[Exception], List[Type[Exception]]] = Exception,
+    delay: int = 0,
+):
+    """Retry Decorator"""
+
+    def _decorator(func: Any):
+        def _newfn(*args: Any, **kwargs: Any):
+
+            attempt = 0
+            while attempt < tries:
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as e:  # type: ignore
+                    logger.debug(repr(e))
+                    logger.warning(f"Retrying `{func}` | Attempt {attempt}")
+
+                    attempt += 1
+                    time.sleep(delay)
+
+            return func(*args, **kwargs)
+
+        return _newfn
+
+    return _decorator

--- a/titiler/pgstac/utils.py
+++ b/titiler/pgstac/utils.py
@@ -1,14 +1,14 @@
 """titiler.pgstac utilities."""
 
 import time
-from typing import Any, List, Type, Union
+from typing import Any, Sequence, Type, Union
 
 from titiler.pgstac.logger import logger
 
 
 def retry(
     tries: int,
-    exceptions: Union[Type[Exception], List[Type[Exception]]] = Exception,
+    exceptions: Union[Type[Exception], Sequence[Type[Exception]]] = Exception,
     delay: int = 0,
 ):
     """Retry Decorator"""


### PR DESCRIPTION
This PR adds a `retry` mechanism to avoid error due to connection issue. 

The main idea is to use the `retry` decorator on top of the `execute_query` which is responsible for acquiring the connection within the `pool` and execute the SQL query. 

By default the `execute_query` will be retried only on [`psycopg.OperationalError`](https://www.psycopg.org/psycopg3/docs/api/errors.html#psycopg.OperationalError)

I've used `execute_query` only on the Mosaic backend `PGSTACBackend.get_assets` method which is called on each tile request. We could use it on all other endpoints but they are more easily retried manually 🤷 

cc @bitner @lossyrob @mmcfarland 
