### PR TITLE
bring titiler-pgstac up to speed with titiler>11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Issues and pull requests are more than welcome: https://github.com/stac-utils/ti
 ```bash
 $ git clone https://github.com/stac-utils/titiler-pgstac.git
 $ cd titiler
-$ pip install pre-commit -e .["dev,test"]
+$ pip install pre-commit -e .["dev,test,psycopg-binary"]
 ```
 
 You can then run the tests with the following command:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
 ]
 dependencies = [
-    "titiler.core>=0.10.2,<0.11",
-    "titiler.mosaic>=0.10.2,<0.11",
+    "titiler.core>=0.11.2,<0.12",
+    "titiler.mosaic>=0.11.2,<0.12",
     "geojson-pydantic>=0.4,<0.5",
     "stac-pydantic==2.0.*",
     "fastapi>=0.87,<0.92",

--- a/titiler/pgstac/factory.py
+++ b/titiler/pgstac/factory.py
@@ -39,7 +39,7 @@ from titiler.core.dependencies import (
     RescalingParams,
     StatisticsParams,
 )
-from titiler.core.factory import BaseTilerFactory, img_endpoint_params, templates
+from titiler.core.factory import BaseTilerFactory, img_endpoint_params
 from titiler.core.models.mapbox import TileJSON
 from titiler.core.models.responses import MultiBaseStatisticsGeoJSON
 from titiler.core.resources.enums import ImageType, MediaType, OptionalHeader
@@ -479,7 +479,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                 tilejson_url += f"?{urlencode(request.query_params._list)}"
 
             tms = self.supported_tms.get(TileMatrixSetId)
-            return templates.TemplateResponse(
+            return self.templates.TemplateResponse(
                 name="index.html",
                 context={
                     "request": request,
@@ -608,7 +608,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                         </TileMatrix>"""
                 tileMatrix.append(tm)
 
-            return templates.TemplateResponse(
+            return self.templates.TemplateResponse(
                 "wmts.xml",
                 {
                     "request": request,


### PR DESCRIPTION
@vincentsarago titiler-pgstac is pinned to titiler<0.11 so we will need to do some updates here to get the changes you are making in titiler (e.g. https://github.com/developmentseed/titiler/pull/646) over in eoAPI (https://github.com/developmentseed/eoAPI/issues/79). 

There might be more work required here but the tests are passing for me locally except for an apparent rounding error in one of the mosaic tests, but that test fails on main branch when I run it, too so maybe it's an environment issue.


<details>
  <summary>test output</summary>

  ```bash
  $ python -m pytest --cov titiler.pgstac --cov-report term-missing
  =========================================================================== test session starts ===========================================================================
  platform linux -- Python 3.10.6, pytest-7.3.1, pluggy-1.0.0
  rootdir: /home/henry/workspace/titiler-pgstac
  plugins: anyio-3.6.2, pgsql-1.1.2, cov-4.0.0, asyncio-0.21.0
  asyncio: mode=strict
  collected 16 items                                                                                                                                                        

  tests/test_health.py ..                                                                                                                                             [ 12%]
  tests/test_items.py ..                                                                                                                                              [ 25%]
  tests/test_mosaic.py ....F.......                                                                                                                                   [100%]

  ================================================================================ FAILURES =================================================================================
  ______________________________________________________________________________ test_tilejson ______________________________________________________________________________

  app = <starlette.testclient.TestClient object at 0x7fd008357ac0>

      def test_tilejson(app):
          """Create TileJSON."""
          response = app.get(f"/mosaic/{search_no_bbox}/tilejson.json")
          assert response.status_code == 400
      
          response = app.get(f"/mosaic/{search_no_bbox}/tilejson.json?assets=cog")
          assert response.headers["content-type"] == "application/json"
          assert response.status_code == 200
          resp = response.json()
          assert resp["name"] == search_no_bbox
          assert resp["minzoom"] == 0
          assert resp["maxzoom"] == 24
          assert round(resp["bounds"][0]) == -180
          assert "?assets=cog" in resp["tiles"][0]
      
          response = app.get(
              f"/mosaic/{search_no_bbox}/tilejson.json?assets=cog&scan_limit=100&items_limit=1&time_limit=2&exitwhenfull=False&skipcovered=False"
          )
          assert response.headers["content-type"] == "application/json"
          assert response.status_code == 200
          resp = response.json()
          assert (
              "?assets=cog&scan_limit=100&items_limit=1&time_limit=2&exitwhenfull=False&skipcovered=False"
              in resp["tiles"][0]
          )
      
          response = app.get(f"/mosaic/{search_no_bbox}/tilejson.json?expression=cog")
          assert response.status_code == 200
          resp = response.json()
          assert "?expression=cog" in resp["tiles"][0]
      
          response = app.get(f"/mosaic/{search_no_bbox}/tilejson.json?expression=cog")
          assert response.status_code == 200
          resp = response.json()
          assert "?expression=cog" in resp["tiles"][0]
      
          response = app.get(
              f"/mosaic/{search_no_bbox}/WorldCRS84Quad/tilejson.json?assets=cog"
          )
          assert response.status_code == 200
          resp = response.json()
          assert resp["minzoom"] == 0
          assert resp["maxzoom"] == 17
  >       assert resp["bounds"] == [-180.0, -90.0, 180.0, 90.0]
  E       assert [-180.0, -89....9999988, 90.0] == [-180.0, -90.0, 180.0, 90.0]
  E         At index 1 diff: -89.9999999999994 != -90.0
  E         Use -v to get more diff

  tests/test_mosaic.py:159: AssertionError
  ---------------------------------------------------------------------------- Captured log call ----------------------------------------------------------------------------
  INFO     httpx:_client.py:1013 HTTP Request: GET http://testserver/mosaic/8f5fb37ec266f4b84ec6aa4fe0453c59/tilejson.json "HTTP/1.1 400 Bad Request"
  INFO     httpx:_client.py:1013 HTTP Request: GET http://testserver/mosaic/8f5fb37ec266f4b84ec6aa4fe0453c59/tilejson.json?assets=cog "HTTP/1.1 200 OK"
  INFO     httpx:_client.py:1013 HTTP Request: GET http://testserver/mosaic/8f5fb37ec266f4b84ec6aa4fe0453c59/tilejson.json?assets=cog&scan_limit=100&items_limit=1&time_limit=2&exitwhenfull=False&skipcovered=False "HTTP/1.1 200 OK"
  INFO     httpx:_client.py:1013 HTTP Request: GET http://testserver/mosaic/8f5fb37ec266f4b84ec6aa4fe0453c59/tilejson.json?expression=cog "HTTP/1.1 200 OK"
  INFO     httpx:_client.py:1013 HTTP Request: GET http://testserver/mosaic/8f5fb37ec266f4b84ec6aa4fe0453c59/tilejson.json?expression=cog "HTTP/1.1 200 OK"
  INFO     httpx:_client.py:1013 HTTP Request: GET http://testserver/mosaic/8f5fb37ec266f4b84ec6aa4fe0453c59/WorldCRS84Quad/tilejson.json?assets=cog "HTTP/1.1 200 OK"
  ============================================================================ warnings summary =============================================================================
  tests/test_items.py::test_stac_items
    /home/henry/workspace/titiler-pgstac/env/lib/python3.10/site-packages/rio_tiler/io/base.py:294: UserWarning: No `assets` option passed, will fetch info for all available assets.
      warnings.warn(

  tests/test_mosaic.py::test_tiles
  tests/test_mosaic.py::test_tiles
  tests/test_mosaic.py::test_tiles
  tests/test_mosaic.py::test_tiles
  tests/test_mosaic.py::test_tiles
  tests/test_mosaic.py::test_cql2
    /home/henry/workspace/titiler-pgstac/env/lib/python3.10/site-packages/rasterio/io.py:138: NotGeoreferencedWarning: Dataset has no geotransform, gcps, or rpcs. The identity matrix will be returned.
      return DatasetReader(mempath, driver=driver, sharing=sharing, **kwargs)

  tests/test_mosaic.py::test_tiles
    /home/henry/workspace/titiler-pgstac/env/lib/python3.10/site-packages/morecantile/models.py:363: UserWarning: TileMatrix not found for level: 18 - Creating values from TMS Scale.
      warnings.warn(

  -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

  ---------- coverage: platform linux, python 3.10.6-final-0 -----------
  Name                             Stmts   Miss Branch BrPart  Cover   Missing
  ----------------------------------------------------------------------------
  titiler/pgstac/__init__.py           1      0      0      0   100%
  titiler/pgstac/db.py                10      0      2      1    92%   15->18
  titiler/pgstac/dependencies.py      46      0     12      0   100%
  titiler/pgstac/factory.py          258     11    110     14    92%   119->122, 127->130, 130->exit, 274, 277, 280, 295->300, 300->304, 376, 387, 402->405, 475-482, 558, 585->588, 830->836
  titiler/pgstac/logger.py             2      0      0      0   100%
  titiler/pgstac/main.py              56      1      8      3    94%   53->62, 63->67, 70
  titiler/pgstac/model.py            120     13     18      7    83%   57, 141, 146-148, 153->178, 158-160, 165, 170, 176, 205, 254
  titiler/pgstac/mosaic.py           150     23     40      8    79%   90, 94, 157, 161, 165, 190, 250, 256, 289, 312-339, 356->360, 362, 374, 377
  titiler/pgstac/reader.py            46      4      8      3    87%   59, 80, 86-87
  titiler/pgstac/settings.py          55      1      6      1    97%   77
  titiler/pgstac/utils.py             18      5      2      1    70%   24-30
  ----------------------------------------------------------------------------
  TOTAL                              762     58    206     38    88%

  ========================================================================= short test summary info =========================================================================
  FAILED tests/test_mosaic.py::test_tilejson - assert [-180.0, -89....9999988, 90.0] == [-180.0, -90.0, 180.0, 90.0]
  ================================================================ 1 failed, 15 passed, 8 warnings in 16.06s ================================================================
  ```
</details>