### PR TITLE
fix: locked pypgstac to <0.7.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "stac-pydantic==2.0.*",
     "fastapi>=0.87,<0.95",
     "starlette>=0.21.0,<0.25",
+    "pypgstac<0.7.7",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Just a quick edit to lock pypgstac to the version which does not break the tests. With the latest 0.7.7 release, there are changes which currently break the code. Locked as suggested by @vincentsarago in #99 