### PR TITLE
feat: added proxy header middleware from stac-fastapi

### DIFF
--- a/titiler/pgstac/main.py
+++ b/titiler/pgstac/main.py
@@ -36,24 +36,6 @@ settings = ApiSettings()
 
 app = FastAPI(title=settings.name, version=titiler_pgstac_version)
 
-
-def custom_openapi():
-    if app.openapi_schema:
-        return app.openapi_schema
-    openapi_schema = get_openapi(
-        title="TiTiler PgSTAC",
-        version=titiler_pgstac_version,
-        description="A lightweight STAC API implementation using PostgreSQL as a backend.",
-        routes=app.routes,
-        openapi_version="3.0.1",
-    )
-    app.openapi_schema = openapi_schema
-    return app.openapi_schema
-
-
-app.openapi = custom_openapi
-
-
 @app.on_event("startup")
 async def startup_event() -> None:
     """Connect to database on startup."""

--- a/titiler/pgstac/main.py
+++ b/titiler/pgstac/main.py
@@ -79,10 +79,7 @@ class ProxyHeaderMiddleware:
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Call from stac-fastapi framework."""
         if scope["type"] == "http":
-            proto: str
-            domain: str
-            port: int
-            proto, domain, port = self._get_forwarded_url_parts(scope)
+            proto: str; domain: str; port: int = self._get_forwarded_url_parts(scope)
             scope["scheme"] = proto
             if domain is not None:
                 port_suffix = ""

--- a/titiler/pgstac/main.py
+++ b/titiler/pgstac/main.py
@@ -36,6 +36,7 @@ settings = ApiSettings()
 
 app = FastAPI(title=settings.name, version=titiler_pgstac_version)
 
+
 @app.on_event("startup")
 async def startup_event() -> None:
     """Connect to database on startup."""
@@ -78,13 +79,16 @@ class ProxyHeaderMiddleware:
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Call from stac-fastapi framework."""
         if scope["type"] == "http":
+            proto: str
+            domain: str
+            port: int
             proto, domain, port = self._get_forwarded_url_parts(scope)
             scope["scheme"] = proto
             if domain is not None:
                 port_suffix = ""
                 if port is not None:
                     if (proto == "http" and port != HTTP_PORT) or (
-                            proto == "https" and port != HTTPS_PORT
+                        proto == "https" and port != HTTPS_PORT
                     ):
                         port_suffix = f":{port}"
                 scope["headers"] = self._replace_header_value_by_name(
@@ -95,8 +99,8 @@ class ProxyHeaderMiddleware:
         await self.app(scope, receive, send)
 
     def _get_forwarded_url_parts(self, scope: Scope) -> Tuple[str]:
-        proto = scope.get("scheme", "http")
-        header_host = self._get_header_value_by_name(scope, "host")
+        proto: str = scope.get("scheme", "http")
+        header_host: str = self._get_header_value_by_name(scope, "host")
         if header_host is None:
             domain, port = scope.get("server")
         else:
@@ -123,8 +127,12 @@ class ProxyHeaderMiddleware:
                             # ignore ports that are not valid integers
                             pass
         else:
-            proto = self._get_header_value_by_name(scope, "x-forwarded-proto", proto)
-            port_str = self._get_header_value_by_name(scope, "x-forwarded-port", port)
+            proto: str = self._get_header_value_by_name(
+                scope, "x-forwarded-proto", proto
+            )
+            port_str: str = self._get_header_value_by_name(
+                scope, "x-forwarded-port", port
+            )
             try:
                 port = int(port_str) if port_str is not None else None
             except ValueError:
@@ -134,7 +142,7 @@ class ProxyHeaderMiddleware:
         return (proto, domain, port)
 
     def _get_header_value_by_name(
-            self, scope: Scope, header_name: str, default_value: str = None
+        self, scope: Scope, header_name: str, default_value: str = None
     ) -> str:
         headers = scope["headers"]
         candidates = [
@@ -144,7 +152,7 @@ class ProxyHeaderMiddleware:
 
     @staticmethod
     def _replace_header_value_by_name(
-            scope: Scope, header_name: str, new_value: str
+        scope: Scope, header_name: str, new_value: str
     ) -> List[Tuple[str]]:
         return [
             (name, value)
@@ -203,7 +211,7 @@ app.include_router(algorithms.router, tags=["Algorithms"])
 # Health Check Endpoint
 @app.get("/healthz", description="Health Check", tags=["Health Check"])
 def ping(
-        timeout: int = Query(1, description="Timeout getting SQL connection from the pool.")
+    timeout: int = Query(1, description="Timeout getting SQL connection from the pool.")
 ) -> Dict:
     """Health check."""
     try:

--- a/titiler/pgstac/main.py
+++ b/titiler/pgstac/main.py
@@ -1,13 +1,15 @@
 """TiTiler+PgSTAC FastAPI application."""
 
 import logging
-from typing import Dict
-
+import re
 from fastapi import FastAPI, Query
+from fastapi.openapi.utils import get_openapi
+from http.client import HTTP_PORT, HTTPS_PORT
 from psycopg import OperationalError
 from psycopg_pool import PoolTimeout
 from starlette.middleware.cors import CORSMiddleware
-
+from starlette.middleware.cors import CORSMiddleware as _CORSMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
 from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 from titiler.core.factory import AlgorithmFactory, MultiBaseTilerFactory, TMSFactory
 from titiler.core.middleware import (
@@ -17,6 +19,8 @@ from titiler.core.middleware import (
 )
 from titiler.core.resources.enums import OptionalHeader
 from titiler.mosaic.errors import MOSAIC_STATUS_CODES
+from typing import Dict, Tuple, List
+
 from titiler.pgstac import __version__ as titiler_pgstac_version
 from titiler.pgstac.db import close_db_connection, connect_to_db
 from titiler.pgstac.dependencies import ItemPathParams
@@ -31,6 +35,23 @@ logging.getLogger("rio-tiler").setLevel(logging.ERROR)
 settings = ApiSettings()
 
 app = FastAPI(title=settings.name, version=titiler_pgstac_version)
+
+
+def custom_openapi():
+    if app.openapi_schema:
+        return app.openapi_schema
+    openapi_schema = get_openapi(
+        title="TiTiler PgSTAC",
+        version=titiler_pgstac_version,
+        description="A lightweight STAC API implementation using PostgreSQL as a backend.",
+        routes=app.routes,
+        openapi_version="3.0.1",
+    )
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+
+app.openapi = custom_openapi
 
 
 @app.on_event("startup")
@@ -48,7 +69,6 @@ async def shutdown_event() -> None:
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
 add_exception_handlers(app, MOSAIC_STATUS_CODES)
 
-
 # Set all CORS enabled origins
 if settings.cors_origins:
     app.add_middleware(
@@ -59,7 +79,100 @@ if settings.cors_origins:
         allow_headers=["*"],
     )
 
+
+class ProxyHeaderMiddleware:
+    """
+    Account for forwarding headers when deriving base URL.
+
+    Prioritise standard Forwarded header, look for non-standard X-Forwarded-* if missing.
+    Default to what can be derived from the URL if no headers provided.
+    Middleware updates the host header that is interpreted by starlette when deriving Request.base_url.
+    """
+
+    def __init__(self, app: ASGIApp):
+        """Create proxy header middleware."""
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Call from stac-fastapi framework."""
+        if scope["type"] == "http":
+            proto, domain, port = self._get_forwarded_url_parts(scope)
+            scope["scheme"] = proto
+            if domain is not None:
+                port_suffix = ""
+                if port is not None:
+                    if (proto == "http" and port != HTTP_PORT) or (
+                            proto == "https" and port != HTTPS_PORT
+                    ):
+                        port_suffix = f":{port}"
+                scope["headers"] = self._replace_header_value_by_name(
+                    scope,
+                    "host",
+                    f"{domain}{port_suffix}",
+                )
+        await self.app(scope, receive, send)
+
+    def _get_forwarded_url_parts(self, scope: Scope) -> Tuple[str]:
+        proto = scope.get("scheme", "http")
+        header_host = self._get_header_value_by_name(scope, "host")
+        if header_host is None:
+            domain, port = scope.get("server")
+        else:
+            header_host_parts = header_host.split(":")
+            if len(header_host_parts) == 2:
+                domain, port = header_host_parts
+            else:
+                domain = header_host_parts[0]
+                port = None
+        forwarded = self._get_header_value_by_name(scope, "forwarded")
+        if forwarded is not None:
+            parts = forwarded.split(";")
+            for part in parts:
+                if len(part) > 0 and re.search("=", part):
+                    key, value = part.split("=")
+                    if key == "proto":
+                        proto = value
+                    elif key == "host":
+                        host_parts = value.split(":")
+                        domain = host_parts[0]
+                        try:
+                            port = int(host_parts[1]) if len(host_parts) == 2 else None
+                        except ValueError:
+                            # ignore ports that are not valid integers
+                            pass
+        else:
+            proto = self._get_header_value_by_name(scope, "x-forwarded-proto", proto)
+            port_str = self._get_header_value_by_name(scope, "x-forwarded-port", port)
+            try:
+                port = int(port_str) if port_str is not None else None
+            except ValueError:
+                # ignore ports that are not valid integers
+                pass
+
+        return (proto, domain, port)
+
+    def _get_header_value_by_name(
+            self, scope: Scope, header_name: str, default_value: str = None
+    ) -> str:
+        headers = scope["headers"]
+        candidates = [
+            value.decode() for key, value in headers if key.decode() == header_name
+        ]
+        return candidates[0] if len(candidates) == 1 else default_value
+
+    @staticmethod
+    def _replace_header_value_by_name(
+            scope: Scope, header_name: str, new_value: str
+    ) -> List[Tuple[str]]:
+        return [
+            (name, value)
+            for name, value in scope["headers"]
+            if name.decode() != header_name
+        ] + [(str.encode(header_name), str.encode(new_value))]
+
+
 app.add_middleware(CacheControlMiddleware, cachecontrol=settings.cachecontrol)
+app.add_middleware(ProxyHeaderMiddleware)
 if settings.debug:
     app.add_middleware(TotalTimeMiddleware)
     app.add_middleware(LoggerMiddleware)
@@ -108,7 +221,7 @@ app.include_router(algorithms.router, tags=["Algorithms"])
 # Health Check Endpoint
 @app.get("/healthz", description="Health Check", tags=["Health Check"])
 def ping(
-    timeout: int = Query(1, description="Timeout getting SQL connection from the pool.")
+        timeout: int = Query(1, description="Timeout getting SQL connection from the pool.")
 ) -> Dict:
     """Health check."""
     try:


### PR DESCRIPTION
Hello!

We have been using titiler-pgstac for some time now, and just recently we started putting it behind Azure API Management.

This works nice and fine, however, the URLs that are in the return payload are wrong as the APIM has a different hostname.

I just decided to copy in a proxy middleware part from stac-fastapi. Main might not be the place to add it but that is the general idea. This configuration works for us:

![image](https://github.com/stac-utils/titiler-pgstac/assets/17437897/6a41ce07-f6a1-4a4d-8850-da3c005be0f7)
