### PR TITLE
update to titiler 0.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         args: ["--fix"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.3.0
     hooks:
       - id: mypy
         language_version: python

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 0.5.0 (TBD)
+
+* update `titiler` requirement to `>=0.12.0,<0.13`
+* use `Annotated` Type for Query/Path parameters
+* replace variable `TileMatrixSetId` by `tileMatrixSetId`
+* add `pixel_selection_dependency` attribute to the `MosaicTilerFactory`
+* re-order endpoints in `MosaicTilerFactory` to avoid conflicts between `tiles` and `assets` endpoints
+* remove deprecater `/{searchid}/{z}/{x}/{y}/assets` endpoints
+
 ## 0.4.1 (2023-06-21)
 
 * update `titiler` requirement to `>=0.11.7`

--- a/docs/src/advanced/custom_tilejson.md
+++ b/docs/src/advanced/custom_tilejson.md
@@ -3,19 +3,24 @@ Goal: enable users to select a predefined configuration stored in the mosaic Met
 
 
 ```python
+import sys
 from typing import Optional
 from dataclasses import dataclass
 
 from morecantile import TileMatrixSet
 from titiler.core.resources.enums import ImageType
 from titiler.core.models.mapbox import TileJSON
-from titiler.mosaic.resources.enums import PixelSelectionMethod
 from titiler.pgstac import factory as TitilerPgSTACFactory
 from titiler.pgstac.dependencies import PgSTACParams
 
-from fastapi import Body, Depends, Query
+from fastapi import Depends, Query
 
 from starlette.requests import Request
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated  # pylint: disable=no-name-in-module
+else:
+    from typing_extensions import Annotated
 
 
 @dataclass
@@ -32,7 +37,7 @@ class MosaicTilerFactory(TitilerPgSTACFactory.MosaicTilerFactory):
             response_model_exclude_none=True,
         )
         @self.router.get(
-            "/{searchid}/{TileMatrixSetId}/tilejson.json",
+            "/{searchid}/{tileMatrixSetId}/tilejson.json",
             response_model=TileJSON,
             responses={200: {"description": "Return a tilejson"}},
             response_model_exclude_none=True,
@@ -40,46 +45,59 @@ class MosaicTilerFactory(TitilerPgSTACFactory.MosaicTilerFactory):
         def tilejson(
             request: Request,
             searchid=Depends(self.path_dependency),
-            tms: TileMatrixSet = Depends(self.tms_dependency),
-            tile_format: Optional[ImageType] = Query(
-                None, description="Output image type. Default is auto."
-            ),
-            tile_scale: int = Query(
-                1, gt=0, lt=4, description="Tile size scale. 1=256x256, 2=512x512..."
-            ),
-            minzoom: Optional[int] = Query(
-                None, description="Overwrite default minzoom."
-            ),
-            maxzoom: Optional[int] = Query(
-                None, description="Overwrite default maxzoom."
-            ),
-            layer_params=Depends(self.layer_dependency),  # noqa
-            dataset_params=Depends(self.dataset_dependency),  # noqa
-            pixel_selection: PixelSelectionMethod = Query(
-                PixelSelectionMethod.first, description="Pixel selection method."
-            ),  # noqa
-            buffer: Optional[float] = Query(
-                None,
-                gt=0,
-                alias="buffer",
-                title="Tile buffer.",
-                description="Buffer on each side of the given tile. It must be a multiple of `0.5`. Output **tilesize** will be expanded to `tilesize + 2 * buffer` (e.g 0.5 = 257x257, 1.0 = 258x258).",
-            ),  # noqa
-            post_process=Depends(self.process_dependency),  # noqa
-            rescale: Optional[List[Tuple[float, ...]]] = Depends(
-                RescalingParams
-            ),  # noqa
-            color_formula: Optional[str] = Query(
-                None,
-                title="Color Formula",
-                description="rio-color formula (info: https://github.com/mapbox/rio-color)",
-            ),  # noqa
-            colormap=Depends(self.colormap_dependency),  # noqa
-            render_params=Depends(self.render_dependency),  # noqa
-            pgstac_params: PgSTACParams = Depends(),  # noqa
-            backend_params=Depends(self.backend_dependency),  # noqa
-            reader_params=Depends(self.reader_dependency),  # noqa
-            layer: str = Query(None, description="Name of default configuration"),
+            tileMatrixSetId: Annotated[  # type: ignore
+                Literal[tuple(self.supported_tms.list())],
+                f"Identifier selecting one of the TileMatrixSetId supported (default: '{self.default_tms}')",
+            ] = self.default_tms,
+            layer: Annotated[
+                str,
+                Query(description="Name of default configuration"),
+            ] = None,
+            tile_format: Annotated[
+                Optional[ImageType],
+                Query(
+                    description="Default will be automatically defined if the output image needs a mask (png) or not (jpeg).",
+                ),
+            ] = None,
+            tile_scale: Annotated[
+                Optional[int],
+                Query(
+                    gt=0, lt=4, description="Tile size scale. 1=256x256, 2=512x512..."
+                ),
+            ] = None,
+            minzoom: Annotated[
+                Optional[int],
+                Query(description="Overwrite default minzoom."),
+            ] = None,
+            maxzoom: Annotated[
+                Optional[int],
+                Query(description="Overwrite default maxzoom."),
+            ] = None,
+            layer_params=Depends(self.layer_dependency),
+            dataset_params=Depends(self.dataset_dependency),
+            pixel_selection=Depends(self.pixel_selection_dependency),
+            buffer: Annotated[
+                Optional[float],
+                Query(
+                    gt=0,
+                    title="Tile buffer.",
+                    description="Buffer on each side of the given tile. It must be a multiple of `0.5`. Output **tilesize** will be expanded to `tilesize + 2 * buffer` (e.g 0.5 = 257x257, 1.0 = 258x258).",
+                ),
+            ] = None,
+            post_process=Depends(self.process_dependency),
+            rescale=Depends(self.rescale_dependency),
+            color_formula: Annotated[
+                Optional[str],
+                Query(
+                    title="Color Formula",
+                    description="rio-color formula (info: https://github.com/mapbox/rio-color)",
+                ),
+            ] = None,
+            colormap=Depends(self.colormap_dependency),
+            render_params=Depends(self.render_dependency),
+            pgstac_params: PgSTACParams = Depends(),
+            backend_params=Depends(self.backend_dependency),
+            reader_params=Depends(self.reader_dependency),
         ):
             """Return TileJSON document for a SearchId."""
             with request.app.state.dbpool.connection() as conn:
@@ -97,11 +115,13 @@ class MosaicTilerFactory(TitilerPgSTACFactory.MosaicTilerFactory):
                 "z": "{z}",
                 "x": "{x}",
                 "y": "{y}",
-                "scale": tile_scale,
-                "TileMatrixSetId": tms.identifier,
+                "tileMatrixSetId": tileMatrixSetId,
             }
+            if tile_scale:
+                route_params["scale"] = tile_scale
             if tile_format:
                 route_params["format"] = tile_format.value
+
             tiles_url = self.url_for(request, "tile", **route_params)
 
             qs_key_to_remove = [

--- a/docs/src/advanced/geojson_crop.md
+++ b/docs/src/advanced/geojson_crop.md
@@ -7,22 +7,27 @@ Here is how you can customize `MosaicTilerFactory` to add a *proper* feature end
 
 ```python
 import os
+import sys
+from typing import Optional
 from dataclasses import dataclass
 
-from geojson_pydantic import Feature, FeatureCollection
+from geojson_pydantic import Feature
 from rio_tiler.constants import MAX_THREADS
 
 from titiler.core.factory import img_endpoint_params
 from titiler.core.resources.enums import ImageType, OptionalHeader
-from titiler.core.utils import Timer
-from titiler.mosaic.resources.enums import PixelSelectionMethod
 from titiler.pgstac import factory as TitilerPgSTACFactory
 from titiler.pgstac.dependencies import PgSTACParams
 
-from fastapi import Body, Depends, Path, Query
+from fastapi import Body, Depends, Query
 
 from starlette.requests import Request
 from starlette.responses import Response
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated  # pylint: disable=no-name-in-module
+else:
+    from typing_extensions import Annotated
 
 
 @dataclass
@@ -33,54 +38,61 @@ class MosaicTilerFactory(TitilerPgSTACFactory.MosaicTilerFactory):
         """This Method register routes to the router."""
         super().register_routes()
 
-    # POST endpoints
-    @self.router.post(
-        "/{searchid}/feature", **img_endpoint_params,
-    )
-    @self.router.post(
-        "/{searchid}/feature.{format}", **img_endpoint_params,
-    )
-    def geojson_crop(
-        request: Request,
-        searchid=Depends(self.path_dependency),
-        geojson: Feature = Body(..., description="GeoJSON Feature."),
-        format: ImageType = Query(
-            None, description="Output image type. Default is auto."
-        ),
-        layer_params=Depends(self.layer_dependency),
-        dataset_params=Depends(self.dataset_dependency),
-        pixel_selection: PixelSelectionMethod = Query(
-            PixelSelectionMethod.first, description="Pixel selection method."
-        ),
-        max_size: int = Query(1024, description="Maximum image size to read onto."),
-        post_process=Depends(self.process_dependency),
-        rescale: Optional[List[Tuple[float, ...]]] = Depends(RescalingParams),
-        color_formula: Optional[str] = Query(
-            None,
-            title="Color Formula",
-            description="rio-color formula (info: https://github.com/mapbox/rio-color)",
-        ),
-        colormap=Depends(self.colormap_dependency),
-        render_params=Depends(self.render_dependency),
-        pgstac_params: PgSTACParams = Depends(),
-    ):
-        """Create image from a geojson feature."""
-        timings = []
-        headers: Dict[str, str] = {}
+        # POST endpoints
+        @self.router.post(
+            "/{searchid}/feature", **img_endpoint_params,
+        )
+        @self.router.post(
+            "/{searchid}/feature.{format}", **img_endpoint_params,
+        )
+        def geojson_crop(
+            request: Request,
+            geojson: Annotated[
+                Feature,
+                Body(description="GeoJSON Feature."),
+            ],
+            searchid=Depends(self.path_dependency),
+            format: Annotated[
+                ImageType,
+                "Default will be automatically defined if the output image needs a mask (png) or not (jpeg).",
+            ] = None,
+            layer_params=Depends(self.layer_dependency),
+            dataset_params=Depends(self.dataset_dependency),
+            pixel_selection=Depends(self.pixel_selection_dependency),
+            buffer: Annotated[
+                Optional[float],
+                Query(
+                    gt=0,
+                    title="Tile buffer.",
+                    description="Buffer on each side of the given tile. It must be a multiple of `0.5`. Output **tilesize** will be expanded to `tilesize + 2 * buffer` (e.g 0.5 = 257x257, 1.0 = 258x258).",
+                ),
+            ] = None,
+            post_process=Depends(self.process_dependency),
+            rescale=Depends(self.rescale_dependency),
+            color_formula: Annotated[
+                Optional[str],
+                Query(
+                    title="Color Formula",
+                    description="rio-color formula (info: https://github.com/mapbox/rio-color)",
+                ),
+            ] = None,
+            colormap=Depends(self.colormap_dependency),
+            render_params=Depends(self.render_dependency),
+            pgstac_params: PgSTACParams = Depends(),
+            backend_params=Depends(self.backend_dependency),
+            reader_params=Depends(self.reader_dependency),
+            env=Depends(self.environment_dependency),
+        ):
+            """Create image from a geojson feature."""
+            threads = int(os.getenv("MOSAIC_CONCURRENCY", MAX_THREADS))
 
-        threads = int(os.getenv("MOSAIC_CONCURRENCY", MAX_THREADS))
-
-        with Timer() as t:
             with rasterio.Env(**self.gdal_config):
                 with self.reader(
                     searchid,
-                    pool=request.app.state.dbpool,
-                    **self.backend_options,
+                    reader_options={**reader_params},
+                    **backend_params,
                 ) as src_dst:
-                    mosaic_read = t.from_start
-                    timings.append(("mosaicread", round(mosaic_read * 1000, 2)))
-
-                    image, _ = src_dst.feature(
+                    image, assets = src_dst.feature(
                         geojson.dict(exclude_none=True),
                         pixel_selection=pixel_selection.method(),
                         threads=threads,
@@ -90,9 +102,6 @@ class MosaicTilerFactory(TitilerPgSTACFactory.MosaicTilerFactory):
                         **pgstac_params,
                     )
 
-        timings.append(("dataread", round(t.elapsed * 1000, 2)))
-
-        with Timer() as t:
             if post_process:
                 image = post_process(image)
 
@@ -101,28 +110,23 @@ class MosaicTilerFactory(TitilerPgSTACFactory.MosaicTilerFactory):
 
             if color_formula:
                 image.apply_color_formula(color_formula)
-        timings.append(("postprocess", round(t.elapsed * 1000, 2)))
 
-        if not format:
-            format = ImageType.jpeg if image.mask.all() else ImageType.png
+            if colormap:
+                image = image.apply_colormap(colormap)
 
-        with Timer() as t:
+            if not format:
+                format = ImageType.jpeg if image.mask.all() else ImageType.png
+
             content = image.render(
                 img_format=format.driver,
-                colormap=colormap,
                 **format.profile,
                 **render_params,
             )
-        timings.append(("format", round(t.elapsed * 1000, 2)))
 
-        if OptionalHeader.server_timing in self.optional_headers:
-            headers["Server-Timing"] = ", ".join(
-                [f"{name};dur={time}" for (name, time) in timings]
-            )
+            headers: Dict[str, str] = {}
+            if OptionalHeader.x_assets in self.optional_headers:
+                ids = [x["id"] for x in assets]
+                headers["X-Assets"] = ",".join(ids)
 
-        if OptionalHeader.x_assets in self.optional_headers:
-            ids = [x["id"] for x in data.assets]
-            headers["X-Assets"] = ",".join(ids)
-
-        return Response(content, media_type=format.mediatype, headers=headers)
+            return Response(content, media_type=format.mediatype, headers=headers)
 ```

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -4,9 +4,9 @@
 
 By default the main application (`titiler.pgstac.main.app`) provides two sets of endpoints:
 
-- `/mosaic`: Dynamic mosaic tiler based on STAC Queries
+- `/mosaic/{searchid}`: Dynamic mosaic tiler based on STAC Search Queries
 
-- `/stac`: Dynamic tiler for single STAC item (stored in PgSTAC)
+- `/collections/{collection_id}/items/{item_id}`: Dynamic tiler for single STAC item (stored in PgSTAC)
 
 ## Mosaic
 
@@ -222,12 +222,12 @@ curl 'http://127.0.0.1:8081/mosaic/f1ed59f0a6ad91ed80ae79b7b52bc707/tiles/8/40/1
 
 ## Items
 
-Set of endpoints created using TiTiler's [`MultiBaseTilerFactory`]() but with `item` and `collection` query parameter (instead of the default `url`).
+Set of endpoints created using TiTiler's [`MultiBaseTilerFactory`]() but with `item` and `collection` path parameter (instead of the `url=` query parameter).
 
 **example**
 
 ```bash
-curl http://127.0.0.1:8081/stac/info?collection=landsat-c2l2-sr&item=LC08_L1TP_028004_20171002_20171018_01_A1
+curl http://127.0.0.1:8081/collections/landsat-c2l2-sr/items/LC08_L1TP_028004_20171002_20171018_01_A1
 ```
 
 See full list of [endpoints](../item_endpoints)

--- a/docs/src/mosaic_endpoints.md
+++ b/docs/src/mosaic_endpoints.md
@@ -6,7 +6,6 @@ The `titiler.pgstac` package comes with a full FastAPI application with Mosaic a
 | `GET`  | `/mosaic/{searchid}/info`                                                        | JSON ([Info][info_model])         | Return **Search** query infos
 | `GET`  | `/mosaic/list`                                                                   | JSON ([Infos][infos_model])       | Return list of **Search** entries with `Mosaic` type
 | `GET`  | `/mosaic/{searchid}/{lon},{lat}/assets`                                          | JSON                              | Return a list of assets which overlap a given point
-| `GET`  | `/mosaic/{searchid}[/{TileMatrixSetId}]/{z}/{x}/{Y}/assets` **DEPRECATED**       | JSON                              | Return a list of assets which overlap a given tile
 | `GET`  | `/mosaic/{searchid}/tiles[/{TileMatrixSetId}]/{z}/{x}/{Y}/assets`                | JSON                              | Return a list of assets which overlap a given tile
 | `GET`  | `/mosaic/{searchid}/tiles[/{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]` | image/bin                         | Create a web map tile image for a search query and a tile index
 | `GET`  | `/mosaic/{searchid}[/{TileMatrixSetId}]/tilejson.json`                           | JSON ([TileJSON][tilejson_model]) | Return a Mapbox TileJSON document

--- a/docs/src/tiler_factories.md
+++ b/docs/src/tiler_factories.md
@@ -24,16 +24,18 @@ mosaic = MosaicTilerFactory()
 app.include_router(mosaic.router)
 ```
 
-| Method | URL                                                                       | Output                            | Description
-| ------ | --------------------------------------------------------------------------|-----------------------------------|--------------
-| `POST` | `/register`                                                               | JSON ([Register][register_model]) | Register **Search** query
-| `GET`  | `/{searchid}/info`                                                        | JSON ([Info][info_model])         | Return **Search** query infos
-| `GET`  | `/{searchid}/{lon},{lat}/assets`                                          | JSON                              | Return a list of assets which overlap a given point
-| `GET`  | `/{searchid}/tiles[/{TileMatrixSetId}]/{z}/{x}/{Y}/assets`                | JSON                              | Return a list of assets which overlap a given tile
-| `GET`  | `/{searchid}/tiles[/{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]` | image/bin                         | Create a web map tile image for a search query and a tile index
-| `GET`  | `/{searchid}[/{TileMatrixSetId}]/tilejson.json`                           | JSON ([TileJSON][tilejson_model]) | Return a Mapbox TileJSON document
-| `GET`  | `/{searchid}[/{TileMatrixSetId}]/WMTSCapabilities.xml`                    | XML                               | return OGC WMTS Get Capabilities
-| `GET`  | `/{searchid}[/{TileMatrixSetId}]/map`                                     | HTML                              | simple map viewer
+| Method | URL                                                                       | Output                                  | Description
+| ------ | --------------------------------------------------------------------------|---------------------------------------- |--------------
+| `POST` | `/register`                                                               | JSON ([Register][register_model])       | Register **Search** query  **OPTIONAL**
+| `GET`  | `/list`                                                                   | JSON ([Info][info_model])               | Return **Search** query infos  **OPTIONAL**
+| `GET`  | `/{searchid}/info`                                                        | JSON ([Infos][infos_model])             | Return list of **Search** entries with `Mosaic` type  **OPTIONAL**
+| `GET`  | `/{searchid}/{lon},{lat}/assets`                                          | JSON                                    | Return a list of assets which overlap a given point
+| `GET`  | `/{searchid}/tiles[/{TileMatrixSetId}]/{z}/{x}/{Y}/assets`                | JSON                                    | Return a list of assets which overlap a given tile
+| `GET`  | `/{searchid}/tiles[/{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]` | image/bin                               | Create a web map tile image for a search query and a tile index
+| `GET`  | `/{searchid}[/{TileMatrixSetId}]/tilejson.json`                           | JSON ([TileJSON][tilejson_model])       | Return a Mapbox TileJSON document
+| `GET`  | `/{searchid}[/{TileMatrixSetId}]/WMTSCapabilities.xml`                    | XML                                     | return OGC WMTS Get Capabilities
+| `GET`  | `/{searchid}[/{TileMatrixSetId}]/map`                                     | HTML                                    | simple map viewer **OPTIONAL**
+| `POST` | `/{searchid}/statistics`                                                  | GeoJSON ([Statistics][statitics_model]) | Return statistics for geojson features **OPTIONAL**
 
 ## Item
 
@@ -73,4 +75,6 @@ app.include_router(item.router, prefix="/collections/{collection_id}/items/{item
 
 [tilejson_model]: https://github.com/developmentseed/titiler/blob/2335048a407f17127099cbbc6c14e1328852d619/src/titiler/core/titiler/core/models/mapbox.py#L16-L38
 [info_model]: https://github.com/stac-utils/titiler-pgstac/blob/047315da8851a974660032ca45f219db2c3a8d54/titiler/pgstac/model.py#L236-L240
+[infos_model]: https://github.com/stac-utils/titiler-pgstac/blob/4f569fee1946f853be9b9149cb4dd2fd5c62b110/titiler/pgstac/model.py#L260-L265
 [register_model]: https://github.com/stac-utils/titiler-pgstac/blob/047315da8851a974660032ca45f219db2c3a8d54/titiler/pgstac/model.py#L229-L233
+[statitics_model]: https://github.com/developmentseed/titiler/blob/17cdff2f0ddf08dbd9a47c2140b13c4bbcc30b6d/src/titiler/core/titiler/core/models/responses.py#L49-L52

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,11 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
 ]
 dependencies = [
-    "titiler.core>=0.11.7,<0.12",
-    "titiler.mosaic>=0.11.7,<0.12",
+    "titiler.core>=0.12.0,<0.13",
+    "titiler.mosaic>=0.12.0,<0.13",
     "geojson-pydantic",
     "stac-pydantic==2.0.*",
-    "fastapi>=0.87,<0.95",
-    "starlette>=0.21.0,<0.25",
+    "pydantic~=1.0",
 ]
 dynamic = ["version"]
 

--- a/titiler/pgstac/mosaic.py
+++ b/titiler/pgstac/mosaic.py
@@ -17,7 +17,7 @@ from morecantile import TileMatrixSet
 from psycopg import errors as pgErrors
 from psycopg_pool import ConnectionPool
 from rasterio.crs import CRS
-from rasterio.warp import transform_geom
+from rasterio.warp import transform, transform_bounds, transform_geom
 from rio_tiler.constants import WEB_MERCATOR_TMS, WGS84_CRS
 from rio_tiler.errors import InvalidAssetName, PointOutsideBounds
 from rio_tiler.io import Reader
@@ -87,15 +87,27 @@ class CustomSTACReader(MultiBaseReader):
 
         """
         if asset not in self.assets:
-            raise InvalidAssetName(f"{asset} is not valid")
+            raise InvalidAssetName(
+                f"{asset} is not valid. Should be one of {self.assets}"
+            )
 
-        info = AssetInfo(url=self.input["assets"][asset]["href"])
-        if "file:header_size" in self.input["assets"][asset]:
-            info["env"] = {
-                "GDAL_INGESTED_BYTES_AT_OPEN": self.input["assets"][asset][
-                    "file:header_size"
-                ]
-            }
+        asset_info = self.input["assets"][asset]
+        info = AssetInfo(
+            url=asset_info["href"],
+            env={},
+        )
+
+        if header_size := asset_info.get("file:header_size"):
+            info["env"]["GDAL_INGESTED_BYTES_AT_OPEN"] = header_size
+
+        if bands := asset_info.get("raster:bands"):
+            stats = [
+                (b["statistics"]["minimum"], b["statistics"]["maximum"])
+                for b in bands
+                if {"minimum", "maximum"}.issubset(b.get("statistics", {}))
+            ]
+            if len(stats) == len(bands):
+                info["dataset_statistics"] = stats
 
         return info
 
@@ -119,11 +131,11 @@ class PGSTACBackend(BaseBackend):
     reader: Type[CustomSTACReader] = attr.ib(init=False, default=CustomSTACReader)
     reader_options: Dict = attr.ib(factory=dict)
 
-    geographic_crs: CRS = attr.ib(default=WGS84_CRS)
-
     # default values for bounds
     bounds: BBox = attr.ib(default=(-180, -90, 180, 90))
+
     crs: CRS = attr.ib(default=WGS84_CRS)
+    geographic_crs: CRS = attr.ib(default=WGS84_CRS)
 
     # The reader is read-only (outside init)
     mosaic_def: MosaicJSON = attr.ib(init=False)
@@ -136,7 +148,7 @@ class PGSTACBackend(BaseBackend):
         # mosaic_def has to be defined.
         # we set `tiles` to an empty list.
         self.mosaic_def = MosaicJSON(
-            mosaicjson="0.0.2",
+            mosaicjson="0.0.3",
             name=self.input,
             bounds=self.bounds,
             minzoom=self.minzoom,
@@ -169,13 +181,24 @@ class PGSTACBackend(BaseBackend):
         bbox = self.tms.bounds(morecantile.Tile(x, y, z))
         return self.get_assets(Polygon.from_bounds(*bbox), **kwargs)
 
-    def assets_for_point(self, lng: float, lat: float, **kwargs: Any) -> List[Dict]:
+    def assets_for_point(
+        self,
+        lng: float,
+        lat: float,
+        coord_crs: CRS = WGS84_CRS,
+        **kwargs: Any,
+    ) -> List[Dict]:
         """Retrieve assets for point."""
         # Point search is currently broken within PgSTAC
         # in order to return the correct result we need to make sure exitwhenfull and skipcovered options
         # are set to `False`
         # ref: https://github.com/stac-utils/pgstac/pull/52
         kwargs.update(**{"exitwhenfull": False, "skipcovered": False})
+
+        if coord_crs != WGS84_CRS:
+            xs, ys = transform(coord_crs, WGS84_CRS, [lng], [lat])
+            lng, lat = xs[0], ys[0]
+
         return self.get_assets(Point(type="Point", coordinates=(lng, lat)), **kwargs)
 
     def assets_for_bbox(
@@ -184,9 +207,20 @@ class PGSTACBackend(BaseBackend):
         ymin: float,
         xmax: float,
         ymax: float,
+        coord_crs: CRS = WGS84_CRS,
         **kwargs: Any,
     ) -> List[Dict]:
         """Retrieve assets for bbox."""
+        if coord_crs != WGS84_CRS:
+            xmin, ymin, xmax, ymax = transform_bounds(
+                coord_crs,
+                WGS84_CRS,
+                xmin,
+                ymin,
+                xmax,
+                ymax,
+            )
+
         return self.get_assets(Polygon.from_bounds(xmin, ymin, xmax, ymax), **kwargs)
 
     @cached(  # type: ignore
@@ -300,6 +334,7 @@ class PGSTACBackend(BaseBackend):
         self,
         lon: float,
         lat: float,
+        coord_crs: CRS = WGS84_CRS,
         reverse: bool = False,
         scan_limit: Optional[int] = None,
         items_limit: Optional[int] = None,
@@ -312,6 +347,7 @@ class PGSTACBackend(BaseBackend):
         mosaic_assets = self.assets_for_point(
             lon,
             lat,
+            coord_crs=coord_crs,
             scan_limit=scan_limit,
             items_limit=items_limit,
             time_limit=time_limit,
@@ -328,10 +364,11 @@ class PGSTACBackend(BaseBackend):
             item: Dict[str, Any],
             lon: float,
             lat: float,
+            coord_crs=coord_crs,
             **kwargs: Any,
         ) -> Dict:
             with self.reader(item, **self.reader_options) as src_dst:
-                return src_dst.point(lon, lat, **kwargs)
+                return src_dst.point(lon, lat, coord_crs=coord_crs, **kwargs)
 
         if "allowed_exceptions" not in kwargs:
             kwargs.update({"allowed_exceptions": (PointOutsideBounds,)})
@@ -356,7 +393,7 @@ class PGSTACBackend(BaseBackend):
         if "geometry" in shape:
             shape = shape["geometry"]
 
-        # PgSTAC except geometry in WGS84
+        # PgSTAC needs geometry in WGS84
         shape_wgs84 = shape
         if shape_crs != WGS84_CRS:
             shape_wgs84 = transform_geom(shape_crs, WGS84_CRS, shape)


### PR DESCRIPTION
This PR does:

- update to latest titiler update (enable FastAPI >0.95, new rio-tiler/morecantile/cogeo-mosaic)
- remove deprecated `/assets` endpoints
- add `coord-crs` option in `/{lon},{lat}/assets` endpoint
- forward STAC asset statistics to ImageData output
- re-order endpoints to avoid conflicts 