### PR TITLE
change openapi/docs url and update landing page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 * remove deprecated `/{searchid}/{z}/{x}/{y}/assets` endpoints
 * remove `stac-pydantic` dependency
 * replace Enum's with `Literal` types
+* add optional `root_path` setting to specify a url path prefix to use when running the app behind a reverse proxy
+* use /api and /api.html for documentation (instead of /openapi.json and /docs)
 
 ## 0.4.1 (2023-06-21)
 

--- a/titiler/pgstac/main.py
+++ b/titiler/pgstac/main.py
@@ -30,7 +30,23 @@ logging.getLogger("rio-tiler").setLevel(logging.ERROR)
 
 settings = ApiSettings()
 
-app = FastAPI(title=settings.name, version=titiler_pgstac_version)
+app = FastAPI(
+    title=settings.name,
+    openapi_url="/api",
+    docs_url="/api.html",
+    description="""Dynamic Raster Tiler with PgSTAC backend.
+
+---
+
+**Documentation**: <a href="https://stac-utils.github.io/titiler-pgstac/" target="_blank">https://stac-utils.github.io/titiler-pgstac/</a>
+
+**Source Code**: <a href="https://github.com/stac-utils/titiler-pgstac" target="_blank">https://github.com/stac-utils/titiler-pgstac</a>
+
+---
+    """,
+    version=titiler_pgstac_version,
+    root_path=settings.root_path,
+)
 
 
 @app.on_event("startup")

--- a/titiler/pgstac/settings.py
+++ b/titiler/pgstac/settings.py
@@ -19,6 +19,7 @@ class ApiSettings(BaseSettings):
     name: str = "titiler-pgstac"
     cors_origins: str = "*"
     cachecontrol: str = "public, max-age=3600"
+    root_path: str = ""
     debug: bool = False
 
     @validator("cors_origins")


### PR DESCRIPTION
FYI @ivica3730k I've added `root_path` settings (which was missing), it might not fix the issue but I know root_path was previously mentioned in titiler repo when using proxy (https://github.com/developmentseed/titiler/pull/343)

closes #110 