### PR TITLE
add searchInfoExtension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,24 @@
     assert resp.json()["id"]
     ```
 
+* move `/{search_id}/info` endpoint outside the `MosaicTilerFactory` to its own *extension* (`titiler.pgstac.extension.searchInfoExtension`)
+
+    ```python
+    # Before
+    app = FastAPI()
+    mosaic = MosaicTilerFactory()
+    app.include_router(mosaic.router, tags=["Mosaic"])
+
+    # Now
+    app = FastAPI()
+    mosaic = MosaicTilerFactory(
+        extensions=[
+            searchInfoExtension(),
+        ]
+    )
+    app.include_router(mosaic.router, tags=["Mosaic"])
+    ```
+
 ## 0.8.0 (2023-10-06)
 
 * update titiler requirement to `>=0.14.0,<0.15`

--- a/docs/src/advanced/custom_search.md
+++ b/docs/src/advanced/custom_search.md
@@ -80,7 +80,7 @@ $ curl -s -X 'POST' \
   -H 'accept: application/json' \
   -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJzY29wZSI6InpvbmVfQSJ9.BelzluX7v7kYObix2KSyy1T5gEOQYQn_pyNO5Ri0gWo' \
   -H 'Content-Type: application/json' \
-  -d '{"filter":{"op":"and","args":[{"op":"=","args":[{"property":"collection"},"l1"]}]}}' | jq '.searchid'
+  -d '{"filter":{"op":"and","args":[{"op":"=","args":[{"property":"collection"},"l1"]}]}}' | jq '.id'
 "bbc3c8f4c392436f74de6cd0308469f6"
 
 $ curl -X 'GET' \

--- a/docs/src/advanced/metadata.md
+++ b/docs/src/advanced/metadata.md
@@ -50,7 +50,7 @@
 ```
 curl -X 'POST' 'http://127.0.0.1:8081/mosaic/register' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{"filter": {"op": "=", "args": [{"property": "collection"}, "landsat-c2l2-sr"]}, "metadata": {"name": "landsat mosaic"}}'
 >> {
-  "searchid": "d7fcdefd0457c949ea7a6192bc2c7122",
+  "id": "d7fcdefd0457c949ea7a6192bc2c7122",
   "links": [
     {
       "rel": "metadata",
@@ -75,7 +75,7 @@ curl http://127.0.0.1:8081/mosaic/d7fcdefd0457c949ea7a6192bc2c7122/info | jq '.s
 ```
 curl -X 'POST' 'http://127.0.0.1:8081/mosaic/register' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{"collections": ["noaa-emergency-response"], "bbox": [-87.0251, 36.0999, -85.4249, 36.2251], "filter-lang": "cql-json", "metadata": {"bounds": [-87.0251, 36.0999, -85.4249, 36.2251], "minzoom": 14, "maxzoom": 18, "assets": ["cog"], "defaults": {"true_color": {"bidx": [1, 2, 3]}}}}'
 >> {
-  "searchid":"4b0db3dbd1858d54a3a55f84de97d1ca",
+  "id":"4b0db3dbd1858d54a3a55f84de97d1ca",
   "links":[
     {
       "rel": "metadata",

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -4,7 +4,7 @@
 
 By default the main application (`titiler.pgstac.main.app`) provides two sets of endpoints:
 
-- `/mosaic/{searchid}`: Dynamic mosaic tiler based on STAC Search Queries
+- `/mosaic/{search_id}`: Dynamic mosaic tiler based on STAC Search Queries
 
 - `/collections/{collection_id}/items/{item_id}`: Dynamic tiler for single STAC item (stored in PgSTAC)
 

--- a/docs/src/tiler_factories.md
+++ b/docs/src/tiler_factories.md
@@ -1,6 +1,8 @@
-`TiTiler.PgSTAC` provides a `MosaicTilerFactory` factory which is an helper functions to create FastAPI router (`fastapi.APIRouter`) with a minimal set of endpoints.
 
-## `titiler.pgstac.factory.MosaicTilerFactory`
+
+## Mosaics: `titiler.pgstac.factory.MosaicTilerFactory`
+
+`TiTiler.PgSTAC` provides a `MosaicTilerFactory` factory which is an helper functions to create FastAPI router (`fastapi.APIRouter`) with a minimal set of endpoints.
 
 ```python
 # Minimal PgSTAC Mosaic Application
@@ -26,11 +28,8 @@ mosaic = MosaicTilerFactory()
 app.include_router(mosaic.router)
 ```
 
-| Method | URL                                                                       | Output                                  | Description
-| ------ | --------------------------------------------------------------------------|---------------------------------------- |--------------
-| `POST` | `/register`                                                               | JSON ([Register][register_model])       | Register **Search** query  **OPTIONAL**
-| `GET`  | `/list`                                                                   | JSON ([Info][info_model])               | Return **Search** query infos  **OPTIONAL**
-| `GET`  | `/{search_id}/info`                                                        | JSON ([Infos][infos_model])             | Return list of **Search** entries with `Mosaic` type  **OPTIONAL**
+| Method | URL                                                                        | Output                                  | Description
+| ------ | ---------------------------------------------------------------------------|---------------------------------------- |--------------
 | `GET`  | `/{search_id}/{lon},{lat}/assets`                                          | JSON                                    | Return a list of assets which overlap a given point
 | `GET`  | `/{search_id}/tiles[/{TileMatrixSetId}]/{z}/{x}/{Y}/assets`                | JSON                                    | Return a list of assets which overlap a given tile
 | `GET`  | `/{search_id}/tiles[/{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]` | image/bin                               | Create a web map tile image for a search query and a tile index
@@ -40,13 +39,24 @@ app.include_router(mosaic.router)
 | `POST` | `/{search_id}/statistics`                                                  | GeoJSON ([Statistics][statitics_model]) | Return statistics for geojson features **OPTIONAL**
 | `GET`  | `/{search_id}/bbox/{minx},{miny},{maxx},{maxy}[/{width}x{height}].{format}`| image/bin                               | Create an image from part of a dataset **OPTIONAL**
 | `POST` | `/{search_id}/feature[/{width}x{height}][.{format}]`                       | image/bin                               | Create an image from a GeoJSON feature **OPTIONAL**
+| `POST` | `/register`                                                                | JSON ([Register][register_model])       | Register **Search** query  **OPTIONAL**
+| `GET`  | `/list`                                                                    | JSON ([Info][info_model])               | Return **Search** query infos  **OPTIONAL**
 
 
-## Item
+### Extensions
 
-For the `single STAC item` endpoints we use TiTiler's [`MultiBaseTilerFactory`]() with a custom [`path_dependency`]() to use `item` and `collection` path parameter (instead of the default `url` query param).
+#### `searchInfoExtension`
 
-This custom `path_dependency` will connect to PgSTAC directly to fetch the STAC Item and pass it to a custom [Reader]() based on [`rio_tiler.io.MultiBaseReader`]().
+| Method | URL                                                                        | Output                                  | Description
+| ------ | ---------------------------------------------------------------------------|---------------------------------------- |--------------
+| `GET`  | `/{search_id}/info`                                                        | JSON ([Infos][infos_model])             | Return list of **Search** entries with `Mosaic` type  **OPTIONAL**
+
+
+## Items: `titiler.core.factory.MultiBaseTilerFactory`
+
+For the `single STAC item` endpoints we use TiTiler's [MultiBaseTilerFactory](https://developmentseed.org/titiler/advanced/tiler_factories/#titilercorefactorymultibasetilerfactory) with a custom [`path_dependency`]() to use `item_id` and `collection_id` path parameter (instead of the default `url` query param).
+
+This custom `path_dependency` will connect to PgSTAC directly to fetch the STAC Item and pass it to a custom [Reader](https://github.com/stac-utils/titiler-pgstac/blob/d777eca04770622982121daa2df42d429e8c244d/titiler/pgstac/reader.py#L17-L25).
 
 ```python
 # Minimal PgSTAC Item Application

--- a/titiler/pgstac/extensions.py
+++ b/titiler/pgstac/extensions.py
@@ -1,0 +1,82 @@
+"""titiler.pgstac extensions."""
+
+from dataclasses import dataclass
+from typing import List
+
+from cogeo_mosaic.errors import MosaicNotFoundError
+from fastapi import Depends
+from psycopg.rows import class_row
+from starlette.requests import Request
+from starlette.routing import NoMatchFound
+
+from titiler.core.factory import FactoryExtension
+from titiler.pgstac import model
+from titiler.pgstac.factory import MosaicTilerFactory
+
+
+@dataclass
+class searchInfoExtension(FactoryExtension):
+    """Add /info endpoint"""
+
+    def register(self, factory: MosaicTilerFactory):
+        """Register endpoint to the tiler factory."""
+
+        @factory.router.get(
+            "/{search_id}/info",
+            responses={200: {"description": "Get Search query metadata."}},
+            response_model=model.Info,
+            response_model_exclude_none=True,
+        )
+        def info_search(request: Request, search_id=Depends(factory.path_dependency)):
+            """Get Search query metadata."""
+            with request.app.state.dbpool.connection() as conn:
+                with conn.cursor(row_factory=class_row(model.Search)) as cursor:
+                    cursor.execute(
+                        "SELECT * FROM searches WHERE hash=%s;",
+                        (search_id,),
+                    )
+                    search_info = cursor.fetchone()
+
+            if not search_info:
+                raise MosaicNotFoundError(f"SearchId `{search_id}` not found")
+
+            links: List[model.Link] = [
+                model.Link(
+                    rel="self",
+                    title="Mosaic metadata",
+                    href=factory.url_for(
+                        request, "info_search", search_id=search_info.id
+                    ),
+                ),
+                model.Link(
+                    title="Link for TileJSON (Template URL)",
+                    rel="tilejson",
+                    href=factory.url_for(request, "tilejson", search_id=search_info.id),
+                ),
+            ]
+
+            try:
+                links.append(
+                    model.Link(
+                        rel="map",
+                        title="Link for Map viewer (Template URL)",
+                        href=factory.url_for(
+                            request, "map_viewer", search_id=search_info.id
+                        ),
+                    )
+                )
+            except NoMatchFound:
+                pass
+
+            try:
+                links.append(
+                    model.Link(
+                        rel="wmts",
+                        title="Link for WMTS (Template URL)",
+                        href=factory.url_for(request, "wmts", search_id=search_info.id),
+                    )
+                )
+            except NoMatchFound:
+                pass
+
+            return model.Info(search=search_info, links=links)

--- a/titiler/pgstac/main.py
+++ b/titiler/pgstac/main.py
@@ -25,6 +25,7 @@ from titiler.mosaic.errors import MOSAIC_STATUS_CODES
 from titiler.pgstac import __version__ as titiler_pgstac_version
 from titiler.pgstac.db import close_db_connection, connect_to_db
 from titiler.pgstac.dependencies import ItemPathParams
+from titiler.pgstac.extensions import searchInfoExtension
 from titiler.pgstac.factory import MosaicTilerFactory
 from titiler.pgstac.reader import PgSTACReader
 from titiler.pgstac.settings import ApiSettings, PostgresSettings
@@ -105,6 +106,9 @@ mosaic = MosaicTilerFactory(
     add_viewer=True,
     add_mosaic_list=True,
     add_part=True,
+    extensions=[
+        searchInfoExtension(),
+    ],
 )
 app.include_router(mosaic.router, tags=["Mosaic"], prefix="/mosaic")
 


### PR DESCRIPTION
This PR moves `/{search_id}/info` endpoint outside the `MosaicTilerFactory` to its own *extension* (`titiler.pgstac.extension.searchInfoExtension`)