### PR TITLE
add /collections/{collection_id} endpoints

### DIFF
--- a/.github/workflows/tests/benchmarks.py
+++ b/.github/workflows/tests/benchmarks.py
@@ -21,12 +21,12 @@ port = os.environ.get("PORT", "8081")
         "6/43/31",
     ],
 )
-def test_benchmark_tile(benchmark, tile, mosaic_id):
+def test_benchmark_tile(benchmark, tile, search_id):
     """Benchmark items endpoint."""
 
     def f(input_tile):
         response = httpx.get(
-            f"http://{host}:{port}/mosaics/{mosaic_id}/tiles/{input_tile}?assets=asset"
+            f"http://{host}:{port}/searches/{search_id}/tiles/{input_tile}?assets=asset"
         )
         assert response.status_code == 200
         return response

--- a/.github/workflows/tests/conftest.py
+++ b/.github/workflows/tests/conftest.py
@@ -7,13 +7,13 @@ import pytest
 
 
 @pytest.fixture(scope="session")
-def mosaic_id():
+def search_id():
     """Mosaic ID fixture"""
     host = os.environ.get("HOST", "0.0.0.0")
     port = os.environ.get("PORT", "8081")
 
     query = {"collections": ["world"]}
-    response = httpx.post(f"http://{host}:{port}/mosaics/register", json=query)
+    response = httpx.post(f"http://{host}:{port}/searches/register", json=query)
     assert response.status_code == 200
 
     resp = response.json()

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 
 * add *metadata layers* links in mosaic's `/info` response for TileJSON, map and wmts endpoint links.
 
+* add `CollectionIdParams` dependency to retrieve a SearchId for a CollectionId
+
+* add `/collections/{collection_id}` virtual mosaic endpoints
+
 ### API breaking changes
 
 * rename `dependencies.PathParams` to `dependencies.SearchIdParams`
@@ -20,7 +24,7 @@
     # Before
     app = FastAPI()
     mosaic = MosaicTilerFactory()
-    app.include_router(mosaic.router, tags=["Mosaic"])
+    app.include_router(mosaic.router)
 
     # Now
     app = FastAPI()
@@ -29,7 +33,7 @@
             searchInfoExtension(),
         ]
     )
-    app.include_router(mosaic.router, tags=["Mosaic"])
+    app.include_router(mosaic.router)
     ```
 
 * move `check_query_params` methods outside `MosaicTilerFactory` class
@@ -48,7 +52,7 @@
     app.include_router(mosaic.router, prefix="/mosaics/{search_id}")
     ```
 
-* move `/register` and `/list` endpoint creation outside the `MosaicTilerFactory` class **API breaking change**
+* move `/register` and `/list` endpoint creation outside the `MosaicTilerFactory` class
 
     ```python
     # before
@@ -60,7 +64,7 @@
     # Now
     from titiler.pgstac.factory import (
         MosaicTilerFactory,
-        add_mosaic_list_route,
+        add_search_register_route,
         add_mosaic_register_route,
     )
 
@@ -68,7 +72,7 @@
     app.include_router(mosaic.router, prefix="/{search_id}")
 
     # add /register endpoint
-    add_mosaic_register_route(
+    add_search_register_route(
         app,
         # any dependency we want to validate
         # when creating the tilejson/map links
@@ -86,10 +90,14 @@
         ],
     )
     # add /list endpoint
-    add_mosaic_list_route(app)
+    add_search_list_route(app)
     ```
 
 ### Endpoint breaking changes
+
+* update endpoints Tags (`STAC Search`, `STAC Collection`, `STAC Item`)
+
+* move PgSTAC Search Virtual Mosaic's endpoint from `/mosaic` to `/searches`
 
 * in `model.RegisterResponse` (model used in `/register` endpoint) rename `searchid` by `id`
 
@@ -99,11 +107,9 @@
     assert resp.json()["searchid"]
 
     # now
-    resp = httpx.post("/mosaic/register", body={"collections": ["my-collection"], "filter-lang": "cql-json"})
+    resp = httpx.post("/searches/register", body={"collections": ["my-collection"], "filter-lang": "cql-json"})
     assert resp.json()["id"]
     ```
-
-* move Mosaic's endpoint from `/mosaic` to `/mosaics`
 
 ## 0.8.0 (2023-10-06)
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,0 +1,470 @@
+"""Test titiler.pgstac Mosaic endpoints."""
+
+import io
+from unittest.mock import patch
+
+import rasterio
+from rasterio.crs import CRS
+
+from .conftest import mock_rasterio_open, parse_img
+
+collection_id = "noaa-emergency-response"
+
+
+def test_assets_for_point_collections(app):
+    """Get assets for a Point."""
+    response = app.get(f"/collections/{collection_id}/-85.5,36.1624/assets")
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 2
+    assert list(resp[0]) == ["id", "bbox", "assets", "collection"]
+    assert resp[0]["id"] == "20200307aC0853130w361030"
+    assert resp[1]["id"] == "20200307aC0853000w361030"
+
+    # with coord-crs
+    response = app.get(
+        f"/collections/{collection_id}/-9517816.46282489,4322990.432036275/assets",
+        params={"coord_crs": "epsg:3857"},
+    )
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 2
+
+    # CollectionId not found
+    response = app.get(
+        "/collections/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/-85.5,36.1624/assets"
+    )
+    assert response.status_code == 404
+    resp = response.json()
+    assert resp["detail"] == "CollectionId `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` not found"
+
+
+def test_assets_for_tile_collections(app):
+    """Get assets for a Tile."""
+    response = app.get(f"/collections/{collection_id}/tiles/15/8589/12849/assets")
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 1
+    assert list(resp[0]) == ["id", "bbox", "assets", "collection"]
+    assert resp[0]["id"] == "20200307aC0853900w361030"
+
+    response = app.get(f"/collections/{collection_id}/tiles/15/8601/12849/assets")
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 2
+
+    response = app.get(
+        f"/collections/{collection_id}/tiles/WebMercatorQuad/15/8601/12849/assets"
+    )
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 2
+
+    # With WGS1994Quad TMS
+    response = app.get(
+        f"/collections/{collection_id}/tiles/WGS1984Quad/14/8601/4901/assets"
+    )
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 4
+
+    response = app.get(f"/collections/{collection_id}/tiles/15/8601/12849/assets")
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp) == 2
+
+    # CollectionId not found
+    response = app.get(
+        "/collections/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/tiles/15/8589/12849/assets"
+    )
+    assert response.status_code == 404
+    resp = response.json()
+    assert resp["detail"] == "CollectionId `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` not found"
+
+
+def test_tilejson_collections(app):
+    """Create TileJSON."""
+    response = app.get(f"/collections/{collection_id}/tilejson.json")
+    assert response.status_code == 400
+
+    response = app.get(f"/collections/{collection_id}/tilejson.json?assets=cog")
+    assert response.headers["content-type"] == "application/json"
+    assert response.status_code == 200
+    resp = response.json()
+    assert resp["name"] == f"Mosaic for '{collection_id}' Collection"
+    assert resp["minzoom"] == 0
+    assert resp["maxzoom"] == 24
+    assert round(resp["bounds"][0]) == -180
+    assert "?assets=cog" in resp["tiles"][0]
+
+    response = app.get(
+        f"/collections/{collection_id}/tilejson.json?assets=cog&scan_limit=100&items_limit=1&time_limit=2&exitwhenfull=False&skipcovered=False"
+    )
+    assert response.headers["content-type"] == "application/json"
+    assert response.status_code == 200
+    resp = response.json()
+    assert (
+        "?assets=cog&scan_limit=100&items_limit=1&time_limit=2&exitwhenfull=False&skipcovered=False"
+        in resp["tiles"][0]
+    )
+
+    response = app.get(f"/collections/{collection_id}/tilejson.json?expression=cog")
+    assert response.status_code == 200
+    resp = response.json()
+    assert "?expression=cog" in resp["tiles"][0]
+
+    response = app.get(f"/collections/{collection_id}/tilejson.json?expression=cog")
+    assert response.status_code == 200
+    resp = response.json()
+    assert "?expression=cog" in resp["tiles"][0]
+
+    response = app.get(
+        f"/collections/{collection_id}/WorldCRS84Quad/tilejson.json?assets=cog"
+    )
+    assert response.status_code == 200
+    resp = response.json()
+    assert resp["minzoom"] == 0
+    assert resp["maxzoom"] == 23
+    for xc, yc in zip(resp["bounds"], [-180.0, -90.0, 180.0, 90.0]):
+        assert round(xc, 5) == round(yc, 5)
+    assert "?assets=cog" in resp["tiles"][0]
+
+    response = app.get(
+        f"/collections/{collection_id}/tilejson.json?assets=cog&tile_format=png"
+    )
+    assert response.status_code == 200
+    resp = response.json()
+    assert ".png?assets=cog" in resp["tiles"][0]
+
+    # CollectionId not found
+    response = app.get(
+        "/collections/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/tilejson.json?assets=cog"
+    )
+    assert response.status_code == 404
+    resp = response.json()
+    assert resp["detail"] == "CollectionId `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` not found"
+
+
+@patch("rio_tiler.io.rasterio.rasterio")
+def test_tiles_collections(rio, app):
+    """Create tiles."""
+    rio.open = mock_rasterio_open
+
+    z, x, y = 15, 8589, 12849
+
+    # missing assets
+    response = app.get(f"/collections/{collection_id}/tiles/{z}/{x}/{y}")
+    assert response.status_code == 400
+
+    response = app.get(f"/collections/{collection_id}/tiles/{z}/{x}/{y}?assets=cog")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/jpeg"
+    meta = parse_img(response.content)
+    assert meta["width"] == 256
+    assert meta["height"] == 256
+
+    response = app.get(
+        f"/collections/{collection_id}/tiles/{z}/{x}/{y}?assets=cog&buffer=0.5"
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/jpeg"
+    meta = parse_img(response.content)
+    assert meta["width"] == 257
+    assert meta["height"] == 257
+
+    response = app.get(f"/collections/{collection_id}/tiles/{z}/{x}/{y}.png?assets=cog")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    meta = parse_img(response.content)
+    assert meta["width"] == 256
+    assert meta["height"] == 256
+
+    response = app.get(
+        f"/collections/{collection_id}/tiles/WebMercatorQuad/{z}/{x}/{y}.tif?assets=cog"
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/tiff; application=geotiff"
+    meta = parse_img(response.content)
+    assert meta["crs"] == CRS.from_epsg(3857)
+    assert meta["width"] == 256
+    assert meta["height"] == 256
+
+    response = app.get(
+        f"/collections/{collection_id}/tiles/WorldCRS84Quad/18/137421/78424.tif?assets=cog"
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/tiff; application=geotiff"
+    meta = parse_img(response.content)
+    assert meta["crs"] == CRS.from_epsg(4326)
+    assert meta["width"] == 256
+    assert meta["height"] == 256
+
+    # CollectionId not found
+    response = app.get(
+        "/collections/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/tiles/0/0/0?assets=cog"
+    )
+    assert response.status_code == 404
+    resp = response.json()
+    assert resp["detail"] == "CollectionId `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` not found"
+
+
+def test_wmts_collections(app):
+    """Create wmts document."""
+    # missing assets
+    response = app.get(f"/collections/{collection_id}/WMTSCapabilities.xml")
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "assets must be defined either via expression or assets options."
+    )
+
+    response = app.get(f"/collections/{collection_id}/WMTSCapabilities.xml?assets=cog")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/xml"
+
+    # Validate it's a good WMTS
+    with rasterio.open(io.BytesIO(response.content)) as src:
+        assert src.crs == "epsg:3857"
+        assert src.profile["driver"] == "WMTS"
+
+    response = app.get(
+        f"/collections/{collection_id}/WorldCRS84Quad/WMTSCapabilities.xml?assets=cog"
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/xml"
+
+    # Validate it's a good WMTS
+    with rasterio.open(io.BytesIO(response.content)) as src:
+        assert src.crs == "OGC:CRS84"
+        assert src.profile["driver"] == "WMTS"
+
+
+@patch("rio_tiler.io.rasterio.rasterio")
+def test_statistics_collections(rio, app):
+    """Get Stats."""
+    rio.open = mock_rasterio_open
+
+    feat = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-85.64065933227539, 36.16587374136926],
+                            [-85.64546585083008, 36.161716102717804],
+                            [-85.64443588256836, 36.158043338486344],
+                            [-85.64083099365234, 36.157904740240866],
+                            [-85.63679695129393, 36.15901351934466],
+                            [-85.6358528137207, 36.161577510965],
+                            [-85.63568115234375, 36.16441859292501],
+                            [-85.63902854919434, 36.16511152412467],
+                            [-85.64065933227539, 36.16587374136926],
+                        ]
+                    ],
+                },
+            }
+        ],
+    }
+
+    response = app.post(
+        f"/collections/{collection_id}/statistics", json=feat, params={"max_size": 1024}
+    )
+    assert response.status_code == 400
+
+    response = app.post(
+        f"/collections/{collection_id}/statistics",
+        json=feat,
+        params={"assets": "cog", "max_size": 1024},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/geo+json"
+    assert response.json()["features"][0]["properties"]["statistics"]["cog_b1"]
+
+    response = app.post(
+        f"/collections/{collection_id}/statistics",
+        json=feat["features"][0],
+        params={"assets": "cog", "max_size": 1024},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/geo+json"
+    assert response.json()["properties"]["statistics"]["cog_b1"]
+
+    # CollectionId not found
+    response = app.post(
+        "/collections/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/statistics",
+        json=feat,
+        params={"assets": "cog", "max_size": 1024},
+    )
+    assert response.status_code == 404
+    resp = response.json()
+    assert resp["detail"] == "CollectionId `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` not found"
+
+
+def test_map_collection(app):
+    """test /map endpoint."""
+    response = app.get(f"/collections/{collection_id}/map")
+    assert response.status_code == 400
+
+    response = app.get(f"/collections/{collection_id}/map", params={"assets": "cog"})
+    assert response.status_code == 200
+
+
+@patch("rio_tiler.io.rasterio.rasterio")
+def test_feature_collection(rio, app):
+    """Get feature image."""
+    rio.open = mock_rasterio_open
+
+    feat = {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [-85.64065933227539, 36.16587374136926],
+                    [-85.64546585083008, 36.161716102717804],
+                    [-85.64443588256836, 36.158043338486344],
+                    [-85.64083099365234, 36.157904740240866],
+                    [-85.63679695129393, 36.15901351934466],
+                    [-85.6358528137207, 36.161577510965],
+                    [-85.63568115234375, 36.16441859292501],
+                    [-85.63902854919434, 36.16511152412467],
+                    [-85.64065933227539, 36.16587374136926],
+                ]
+            ],
+        },
+    }
+
+    response = app.post(
+        f"/collections/{collection_id}/feature", json=feat, params={"max_size": 1024}
+    )
+    assert response.status_code == 400
+
+    response = app.post(
+        f"/collections/{collection_id}/feature",
+        json=feat,
+        params={"assets": "cog", "max_size": 1024},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    meta = parse_img(response.content)
+    assert meta["width"] == 725
+    assert meta["height"] == 591
+    assert meta["count"] == 4
+
+    response = app.post(
+        f"/collections/{collection_id}/feature.jpeg",
+        json=feat,
+        params={"assets": "cog", "max_size": 1024},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/jpeg"
+    meta = parse_img(response.content)
+    assert meta["width"] == 725
+    assert meta["height"] == 591
+    assert meta["count"] == 3
+
+    response = app.post(
+        f"/collections/{collection_id}/feature/300x400.jpeg",
+        json=feat,
+        params={"assets": "cog", "max_size": 1024},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/jpeg"
+    meta = parse_img(response.content)
+    assert meta["width"] == 300
+    assert meta["height"] == 400
+    assert meta["count"] == 3
+
+    response = app.post(
+        f"/collections/{collection_id}/feature/300x400.tif",
+        json=feat,
+        params={"assets": "cog", "max_size": 1024},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/tiff; application=geotiff"
+    meta = parse_img(response.content)
+    assert meta["crs"] == "epsg:4326"
+
+    response = app.post(
+        f"/collections/{collection_id}/feature/300x400.tif",
+        json=feat,
+        params={"assets": "cog", "max_size": 1024, "dst_crs": "epsg:3857"},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/tiff; application=geotiff"
+    meta = parse_img(response.content)
+    assert meta["crs"] == "epsg:3857"
+
+
+@patch("rio_tiler.io.rasterio.rasterio")
+def test_bbox_collection(rio, app):
+    """Get bbox image."""
+    rio.open = mock_rasterio_open
+
+    bbox = [
+        -85.64546585083008,
+        36.157904740240866,
+        -85.63568115234375,
+        36.16587374136926,
+    ]
+    str_bbox = ",".join(map(str, bbox))
+    response = app.get(
+        f"/collections/{collection_id}/bbox/{str_bbox}.png", params={"max_size": 1024}
+    )
+    assert response.status_code == 400
+
+    response = app.get(
+        f"/collections/{collection_id}/bbox/{str_bbox}.png",
+        params={"assets": "cog", "max_size": 1024},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    meta = parse_img(response.content)
+    assert meta["width"] == 725
+    assert meta["height"] == 591
+    assert meta["count"] == 4
+
+    response = app.get(
+        f"/collections/{collection_id}/bbox/{str_bbox}.jpeg",
+        params={"assets": "cog", "max_size": 1024},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/jpeg"
+    meta = parse_img(response.content)
+    assert meta["width"] == 725
+    assert meta["height"] == 591
+    assert meta["count"] == 3
+
+    response = app.get(
+        f"/collections/{collection_id}/bbox/{str_bbox}/300x400.jpeg",
+        params={"assets": "cog", "max_size": 1024},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/jpeg"
+    meta = parse_img(response.content)
+    assert meta["width"] == 300
+    assert meta["height"] == 400
+    assert meta["count"] == 3
+
+    response = app.get(
+        f"/collections/{collection_id}/bbox/{str_bbox}.tif",
+        params={"assets": "cog", "max_size": 1024},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/tiff; application=geotiff"
+    meta = parse_img(response.content)
+    assert meta["crs"] == "epsg:4326"
+
+    response = app.get(
+        f"/collections/{collection_id}/bbox/{str_bbox}.tif",
+        params={"assets": "cog", "max_size": 1024, "dst_crs": "epsg:3857"},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/tiff; application=geotiff"
+    meta = parse_img(response.content)
+    assert meta["crs"] == "epsg:3857"

--- a/titiler/pgstac/dependencies.py
+++ b/titiler/pgstac/dependencies.py
@@ -7,9 +7,10 @@ import morecantile
 import pystac
 from cachetools import TTLCache, cached
 from cachetools.keys import hashkey
+from cogeo_mosaic.errors import MosaicNotFoundError
 from fastapi import HTTPException, Path, Query
 from psycopg import errors as pgErrors
-from psycopg.rows import dict_row
+from psycopg.rows import class_row, dict_row
 from psycopg_pool import ConnectionPool
 from starlette.requests import Request
 from typing_extensions import Annotated
@@ -26,11 +27,74 @@ retry_config = RetrySettings()
 def SearchIdParams(
     search_id: Annotated[
         str,
-        Path(description="Search Id (pgSTAC Search Hash)"),
+        Path(description="PgSTAC Search Identifier (Hash)"),
     ]
 ) -> str:
     """search_id"""
     return search_id
+
+
+@cached(  # type: ignore
+    TTLCache(maxsize=cache_config.maxsize, ttl=cache_config.ttl),
+    key=lambda pool, collection_id: hashkey(collection_id),
+)
+@retry(
+    tries=retry_config.retry,
+    delay=retry_config.delay,
+    exceptions=(
+        pgErrors.OperationalError,
+        pgErrors.InterfaceError,
+    ),
+)
+def get_collection_id(pool: ConnectionPool, collection_id: str) -> str:
+    """Get Search Id for a Collection."""
+    search = model.PgSTACSearch(
+        filter={
+            "op": "=",
+            "args": [{"property": "collection"}, collection_id],
+        },
+        filter_lang="cql2-json",  # type: ignore
+    )
+
+    with pool.connection() as conn:
+        with conn.cursor(row_factory=dict_row) as cursor:
+            cursor.execute(
+                "SELECT * FROM pgstac.get_collection(%s);",
+                (collection_id,),
+            )
+            collection = cursor.fetchone()["get_collection"]
+            if not collection:
+                raise MosaicNotFoundError(f"CollectionId `{collection_id}` not found")
+
+            bbox = collection["extent"]["spatial"].get("bbox", [[-180, -90, 180, 90]])
+            metadata = model.Metadata(
+                name=f"Mosaic for '{collection_id}' Collection",
+                bounds=bbox[0],
+                # TODO: use asset extension to populate the `assets` attribute
+            )
+
+            cursor.row_factory = class_row(model.Search)
+            cursor.execute(
+                "SELECT * FROM search_query(%s, _metadata => %s);",
+                (
+                    search.model_dump_json(by_alias=True, exclude_none=True),
+                    metadata.model_dump_json(exclude_none=True),
+                ),
+            )
+            search_info = cursor.fetchone()
+
+    return search_info.id
+
+
+def CollectionIdParams(
+    request: Request,
+    collection_id: Annotated[
+        str,
+        Path(description="STAC Collection Identifier"),
+    ],
+) -> str:
+    """collection_id Path Parameter"""
+    return get_collection_id(request.app.state.dbpool, collection_id=collection_id)
 
 
 def SearchParams(

--- a/titiler/pgstac/dependencies.py
+++ b/titiler/pgstac/dependencies.py
@@ -48,13 +48,7 @@ def SearchIdParams(
 )
 def get_collection_id(pool: ConnectionPool, collection_id: str) -> str:
     """Get Search Id for a Collection."""
-    search = model.PgSTACSearch(
-        filter={
-            "op": "=",
-            "args": [{"property": "collection"}, collection_id],
-        },
-        filter_lang="cql2-json",  # type: ignore
-    )
+    search = model.PgSTACSearch(collections=[collection_id])
 
     with pool.connection() as conn:
         with conn.cursor(row_factory=dict_row) as cursor:

--- a/titiler/pgstac/factory.py
+++ b/titiler/pgstac/factory.py
@@ -883,7 +883,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             return Response(content, media_type=media_type, headers=headers)
 
 
-def add_mosaic_register_route(
+def add_search_register_route(
     app: FastAPI,
     *,
     prefix: str = "",
@@ -1013,13 +1013,13 @@ def add_mosaic_register_route(
         return model.RegisterResponse(id=search_info.id, links=links)
 
 
-def add_mosaic_list_route(  # noqa: C901
+def add_search_list_route(  # noqa: C901
     app: FastAPI,
     *,
     prefix: str = "",
     tags: Optional[List[str]] = None,
 ):
-    """Add mosaic listing route."""
+    """Add PgSTAC Search (of type mosaic) listing route."""
 
     @app.get(
         f"{prefix}/list",
@@ -1028,7 +1028,7 @@ def add_mosaic_list_route(  # noqa: C901
         response_model_exclude_none=True,
         tags=tags,
     )
-    def list_mosaic(  # noqa: C901
+    def list_searches(  # noqa: C901
         request: Request,
         limit: Annotated[
             int,
@@ -1052,7 +1052,7 @@ def add_mosaic_list_route(  # noqa: C901
             ),
         ] = None,
     ):
-        """List a Search query."""
+        """List a PgSTAC Searches."""
         # Default filter to only return `metadata->type == 'mosaic'`
         mosaic_filter = sql.SQL("metadata->>'type' = 'mosaic'")
 
@@ -1126,7 +1126,7 @@ def add_mosaic_list_route(  # noqa: C901
 
         base_url = str(request.base_url)
         list_endpoint = str(
-            app.url_path_for("list_mosaic").make_absolute_url(base_url=base_url)
+            app.url_path_for("list_searches").make_absolute_url(base_url=base_url)
         )
 
         qs = QueryParams({**request.query_params, "limit": limit, "offset": offset})


### PR DESCRIPTION
ref #118 

This PR uses the latest changes in titiler-pgstac to add `/collection/{collection_id}` endpoints 

### Other
- update endpoints Tags 
- add `py.typed` file 
- move mosaic endpoints from `/mosaics/{search_id}` to `/searches/{search_id}`