### PR TITLE
add /{lon},{lat}/values endpoints

### DIFF
--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -468,3 +468,45 @@ def test_bbox_collection(rio, app):
     assert response.headers["content-type"] == "image/tiff; application=geotiff"
     meta = parse_img(response.content)
     assert meta["crs"] == "epsg:3857"
+
+
+def test_query_point_collections(app):
+    """Get values for a Point."""
+    response = app.get(
+        f"/collections/{collection_id}/-85.5,36.1624/values", params={"assets": "cog"}
+    )
+
+    assert response.status_code == 200
+    resp = response.json()
+
+    values = resp["values"]
+    assert len(values) == 2
+    assert values[0][0] == [
+        "https://noaa-eri-pds.s3.us-east-1.amazonaws.com/2020_Nashville_Tornado/20200307a_RGB/20200307aC0853130w361030n.tif"
+    ]
+    assert values[0][2] == ["cog_b1", "cog_b2", "cog_b3"]
+
+    # with coord-crs
+    response = app.get(
+        f"/collections/{collection_id}/-9517816.46282489,4322990.432036275/values",
+        params={"assets": "cog", "coord_crs": "epsg:3857"},
+    )
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp["values"]) == 2
+
+    # CollectionId not found
+    response = app.get(
+        "/collections/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/-85.5,36.1624/values",
+        params={"assets": "cog"},
+    )
+    assert response.status_code == 404
+    resp = response.json()
+    assert resp["detail"] == "CollectionId `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` not found"
+
+    # at a point with no assets
+    response = app.get(
+        f"/collections/{collection_id}/-86.0,-35.0/values", params={"assets": "cog"}
+    )
+
+    assert response.status_code == 204  # (no content)

--- a/tests/test_searches.py
+++ b/tests/test_searches.py
@@ -969,3 +969,45 @@ def test_bbox(rio, app, search_no_bbox):
     assert response.headers["content-type"] == "image/tiff; application=geotiff"
     meta = parse_img(response.content)
     assert meta["crs"] == "epsg:3857"
+
+
+def test_query_point_searches(app, search_no_bbox, search_bbox):
+    """Test getting values for a Point."""
+    response = app.get(
+        f"/searches/{search_no_bbox}/-85.5,36.1624/values", params={"assets": "cog"}
+    )
+
+    assert response.status_code == 200
+    resp = response.json()
+
+    values = resp["values"]
+    assert len(values) == 2
+    assert values[0][0] == [
+        "https://noaa-eri-pds.s3.us-east-1.amazonaws.com/2020_Nashville_Tornado/20200307a_RGB/20200307aC0853130w361030n.tif"
+    ]
+    assert values[0][2] == ["cog_b1", "cog_b2", "cog_b3"]
+
+    # with coord-crs
+    response = app.get(
+        f"/searches/{search_no_bbox}/-9517816.46282489,4322990.432036275/values",
+        params={"assets": "cog", "coord_crs": "epsg:3857"},
+    )
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp["values"]) == 2
+
+    # SearchId not found
+    response = app.get(
+        "/searches/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/-85.5,36.1624/values",
+        params={"assets": "cog"},
+    )
+    assert response.status_code == 404
+    resp = response.json()
+    assert resp["detail"] == "SearchId `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` not found"
+
+    # outside of searchid bbox
+    response = app.get(
+        f"/searches/{search_bbox}/-86.0,35.0/values", params={"assets": "cog"}
+    )
+
+    assert response.status_code == 204  # (no content)

--- a/titiler/pgstac/factory.py
+++ b/titiler/pgstac/factory.py
@@ -51,9 +51,10 @@ from titiler.core.factory import BaseTilerFactory, img_endpoint_params
 from titiler.core.models.mapbox import TileJSON
 from titiler.core.models.responses import MultiBaseStatisticsGeoJSON
 from titiler.core.resources.enums import ImageType, MediaType, OptionalHeader
-from titiler.core.resources.responses import GeoJSONResponse, XMLResponse
+from titiler.core.resources.responses import GeoJSONResponse, JSONResponse, XMLResponse
 from titiler.core.utils import render_image
 from titiler.mosaic.factory import PixelSelectionParams
+from titiler.mosaic.models.responses import Point
 from titiler.pgstac import model
 from titiler.pgstac.dependencies import (
     BackendParams,
@@ -150,6 +151,7 @@ class MosaicTilerFactory(BaseTilerFactory):
         self._tiles_routes()
         self._tilejson_routes()
         self._wmts_routes()
+        self._point_routes()
 
         if self.add_part:
             self._part_routes()
@@ -220,7 +222,6 @@ class MosaicTilerFactory(BaseTilerFactory):
                     reader_options={**reader_params},
                     **backend_params,
                 ) as src_dst:
-
                     if MOSAIC_STRICT_ZOOM and (
                         tile.z < src_dst.minzoom or tile.z > src_dst.maxzoom
                     ):
@@ -900,6 +901,53 @@ class MosaicTilerFactory(BaseTilerFactory):
                 headers["X-Assets"] = ",".join(ids)
 
             return Response(content, media_type=media_type, headers=headers)
+
+    def _point_routes(self):
+        """Register point values endpoint."""
+
+        @self.router.get(
+            "/{lon},{lat}/values",
+            response_model=model.Point,
+            response_class=JSONResponse,
+            responses={200: {"description": "Return a value for a point"}},
+        )
+        def point(
+            lon: Annotated[float, Path(description="Longitude")],
+            lat: Annotated[float, Path(description="Latitude")],
+            search_id=Depends(self.path_dependency),
+            coord_crs=Depends(CoordCRSParams),
+            layer_params=Depends(self.layer_dependency),
+            dataset_params=Depends(self.dataset_dependency),
+            pgstac_params=Depends(self.pgstac_dependency),
+            backend_params=Depends(self.backend_dependency),
+            reader_params=Depends(self.reader_dependency),
+            env=Depends(self.environment_dependency),
+        ):
+            """Get Point value for a Mosaic."""
+            threads = int(os.getenv("MOSAIC_CONCURRENCY", MAX_THREADS))
+
+            with rasterio.Env(**env):
+                with self.reader(
+                    search_id,
+                    reader_options={**reader_params},
+                    **backend_params,
+                ) as src_dst:
+                    values = src_dst.point(
+                        lon,
+                        lat,
+                        coord_crs=coord_crs or WGS84_CRS,
+                        threads=threads,
+                        **layer_params,
+                        **dataset_params,
+                        **pgstac_params,
+                    )
+
+            return {
+                "coordinates": [lon, lat],
+                "values": [
+                    (val.assets, val.data.tolist(), val.band_names) for val in values
+                ],
+            }
 
 
 def add_search_register_route(

--- a/titiler/pgstac/factory.py
+++ b/titiler/pgstac/factory.py
@@ -54,7 +54,6 @@ from titiler.core.resources.enums import ImageType, MediaType, OptionalHeader
 from titiler.core.resources.responses import GeoJSONResponse, JSONResponse, XMLResponse
 from titiler.core.utils import render_image
 from titiler.mosaic.factory import PixelSelectionParams
-from titiler.mosaic.models.responses import Point
 from titiler.pgstac import model
 from titiler.pgstac.dependencies import (
     BackendParams,

--- a/titiler/pgstac/model.py
+++ b/titiler/pgstac/model.py
@@ -5,7 +5,7 @@ Note: This is mostly a copy of https://github.com/stac-utils/stac-fastapi/blob/m
 """
 
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from geojson_pydantic.geometries import Geometry
 from geojson_pydantic.types import BBox
@@ -210,3 +210,15 @@ class Infos(BaseModel):
     searches: List[Info]
     links: Optional[List[Link]] = None
     context: Context
+
+
+class Point(BaseModel):
+    """
+    Point model.
+
+    response model for `/{lon}/{lat}/values` endpoint
+
+    """
+
+    coordinates: List[float]
+    values: List[Tuple[List[str], List[float], List[str]]]

--- a/titiler/pgstac/mosaic.py
+++ b/titiler/pgstac/mosaic.py
@@ -364,7 +364,9 @@ class PGSTACBackend(BaseBackend):
         if "allowed_exceptions" not in kwargs:
             kwargs.update({"allowed_exceptions": (PointOutsideBounds,)})
 
-        tasks = create_tasks(_reader, mosaic_assets, lon=lon, lat=lat, coord_crs=coord_crs, **kwargs)
+        tasks = create_tasks(
+            _reader, mosaic_assets, lon=lon, lat=lat, coord_crs=coord_crs, **kwargs
+        )
 
         return [val for val, _ in filter_tasks(tasks)]
 


### PR DESCRIPTION
I added the capability to query asset values at a point as discussed in https://github.com/stac-utils/titiler-pgstac/discussions/144.

Rather than a dedicated `/point` endpoint, I followed the pattern for querying assets at a lon/lat pair (`{lon}/{lat}/assets`).

I tried to mimic the response class from the analagous titiler endpoint, the only difference is that the `assets` object comes back as a list. It looks like this:
```
{
  'coordinates': [-85.5, 36.1624],
  'values': [
    [
      ['https://noaa-eri-pds.s3.us-east-1.amazonaws.com/2020_Nashville_Tornado/20200307a_RGB/20200307aC0853130w361030n.tif'],
      [27.0, 34.0, 42.0],
      ['cog_b1', 'cog_b2', 'cog_b3']
    ],
    [
      ['https://noaa-eri-pds.s3.us-east-1.amazonaws.com/2020_Nashville_Tornado/20200307a_RGB/20200307aC0853000w361030n.tif'],
      [30.0, 34.0, 43.0],
      ['cog_b1', 'cog_b2', 'cog_b3']
    ]
  ]
}
```

The other odd thing is that if you send a query for a point that doesn't intersect any assets, you get a 204 instead of a 200 with an empty `values` list.