### PR TITLE
update rio-tiler, add align stats and fix morecantile breaking change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.8.2 (2024-01-23)
+
+* update rio-tiler version to `>6.3.0` (defined in `titiler>=0.17`)
+* use new `align_bounds_with_dataset=True` rio-tiler option in GeoJSON statistics methods for more precise calculation [backported from 1.2.0]
+* use morecantile `TileMatrixSet.cellSize` property instead of deprecated/private TileMatrixSet._resolution method [backported from 1.1.0]
+
 ## 0.8.1 (2023-11-10)
 
 * add `algorithm` options for `/statistics [POST]` endpoints

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "titiler.core>=0.15.0,<0.16",
     "titiler.mosaic>=0.15.0,<0.16",
+    "rio-tiler>=6.3.0,<7.0",
     "geojson-pydantic~=1.0",
     "pydantic>=2.4,<3.0",
     "pydantic-settings~=2.0",

--- a/titiler/pgstac/factory.py
+++ b/titiler/pgstac/factory.py
@@ -450,7 +450,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                     "request": request,
                     "tilejson_endpoint": tilejson_url,
                     "tms": tms,
-                    "resolutions": [tms._resolution(matrix) for matrix in tms],
+                    "resolutions": [matrix.cellSize for matrix in tms],
                 },
                 media_type="text/html",
             )
@@ -1083,6 +1083,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                             dst_crs=dst_crs,
                             pixel_selection=pixel_selection,
                             threads=MOSAIC_THREADS,
+                            align_bounds_with_dataset=True,
                             **image_params,
                             **layer_params,
                             **dataset_params,

--- a/titiler/pgstac/main.py
+++ b/titiler/pgstac/main.py
@@ -1,6 +1,7 @@
 """TiTiler+PgSTAC FastAPI application."""
 
 import logging
+import re
 from contextlib import asynccontextmanager
 from typing import Dict
 
@@ -209,6 +210,9 @@ def landing(request: Request):
     }
 
     urlpath = request.url.path
+    if root_path := request.app.root_path:
+        urlpath = re.sub(r"^" + root_path, "", urlpath)
+
     crumbs = []
     baseurl = str(request.base_url).rstrip("/")
 


### PR DESCRIPTION
* update rio-tiler version to `>6.3.0` (defined in `titiler>=0.17`)
* use new `align_bounds_with_dataset=True` rio-tiler option in GeoJSON statistics methods for more precise calculation [backported from 1.2.0]
* use morecantile `TileMatrixSet.cellSize` property instead of deprecated/private TileMatrixSet._resolution method [backported from 1.1.0]
