### PR TITLE
Change db connection kwargs default

### DIFF
--- a/titiler/pgstac/db.py
+++ b/titiler/pgstac/db.py
@@ -1,6 +1,6 @@
 """Database connection handling."""
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from fastapi import FastAPI
 from psycopg_pool import ConnectionPool
@@ -11,7 +11,7 @@ from titiler.pgstac.settings import PostgresSettings
 async def connect_to_db(
     app: FastAPI,
     settings: Optional[PostgresSettings] = None,
-    kwargs: Dict[str, str] = {
+    kwargs: Dict[str, Any] = {
         "options": "-c search_path=pgstac,public -c application_name=pgstac"
     },
 ) -> None:

--- a/titiler/pgstac/db.py
+++ b/titiler/pgstac/db.py
@@ -11,13 +11,17 @@ from titiler.pgstac.settings import PostgresSettings
 async def connect_to_db(
     app: FastAPI,
     settings: Optional[PostgresSettings] = None,
-    kwargs: Dict[str, Any] = {
-        "options": "-c search_path=pgstac,public -c application_name=pgstac"
-    },
+    pool_kwargs: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Connect to Database."""
     if not settings:
         settings = PostgresSettings()
+
+    pool_kwargs = (
+        pool_kwargs
+        if pool_kwargs is not None
+        else {"options": "-c search_path=pgstac,public -c application_name=pgstac"}
+    )
 
     app.state.dbpool = ConnectionPool(
         conninfo=str(settings.database_url),
@@ -26,7 +30,7 @@ async def connect_to_db(
         max_waiting=settings.db_max_queries,
         max_idle=settings.db_max_idle,
         num_workers=settings.db_num_workers,
-        kwargs=kwargs,
+        kwargs=pool_kwargs,
     )
 
     # Make sure the pool is ready

--- a/titiler/pgstac/db.py
+++ b/titiler/pgstac/db.py
@@ -1,6 +1,6 @@
 """Database connection handling."""
 
-from typing import Optional
+from typing import Dict, Optional
 
 from fastapi import FastAPI
 from psycopg_pool import ConnectionPool
@@ -9,7 +9,11 @@ from titiler.pgstac.settings import PostgresSettings
 
 
 async def connect_to_db(
-    app: FastAPI, settings: Optional[PostgresSettings] = None
+    app: FastAPI,
+    settings: Optional[PostgresSettings] = None,
+    kwargs: Dict[str, str] = {
+        "options": "-c search_path=pgstac,public -c application_name=pgstac"
+    },
 ) -> None:
     """Connect to Database."""
     if not settings:
@@ -22,7 +26,7 @@ async def connect_to_db(
         max_waiting=settings.db_max_queries,
         max_idle=settings.db_max_idle,
         num_workers=settings.db_num_workers,
-        kwargs={"options": "-c search_path=pgstac,public -c application_name=pgstac"},
+        kwargs=kwargs,
     )
 
     # Make sure the pool is ready


### PR DESCRIPTION
RDS Proxy does not support command line options and therefore titiler cannot connect to the proxy using the`search_path` option. Make the `ConnectionPool` kwargs optional.