### PR TITLE
Fix dev install instructions so tests will run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Issues and pull requests are more than welcome: https://github.com/stac-utils/ti
 
 ```bash
 $ git clone https://github.com/stac-utils/titiler-pgstac.git
-$ cd titiler
-$ pip install pre-commit -e .["dev,test"]
+$ cd titiler-pgstac
+$ pip install pre-commit -e .["dev,test,psycopg"]
 ```
 
 You can then run the tests with the following command:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Issues and pull requests are more than welcome: https://github.com/stac-utils/ti
 ```bash
 $ git clone https://github.com/stac-utils/titiler-pgstac.git
 $ cd titiler-pgstac
-$ pip install pre-commit -e .["dev,test,psycopg"]
+$ python -m pip install -e ".[dev,test,psycopg]"
 ```
 
 You can then run the tests with the following command:


### PR DESCRIPTION
Adds the `psycopg` extra to the "dev install" `pip install` command.

Also changes `cd titiler` to `cd titiler-pgstac` to move into the `titiler-pgstac` repo (probably leftover copypasta from `titiler` repo 😄)

Closes #166 