### PR TITLE
ci: build docker images on linux/arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           context: .
           file: Dockerfile.${{ matrix.image-version }}
           push: true
@@ -225,7 +225,7 @@ jobs:
         if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           context: .
           file: Dockerfile.${{ matrix.image-version }}
           push: true


### PR DESCRIPTION
**Summary** 
This PR adds `linux/arm64` to a list of platforms docker images are built on. The goal is to make local testing and development easier.

**Backstory**
I got an error `Failed to pull image "ghcr.io/stac-utils/titiler-pgstac:uvicorn-1.3.0": no matching manifest for linux/arm64/v8 in the manifest list entries` while trying to use the image 
```
  image:
    name: ghcr.io/stac-utils/titiler-pgstac
    tag: uvicorn-1.3.0
```
locally on M1 macbook.

