### PR TITLE
Patch/update ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@
 
 version: 2
 updates:
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -12,3 +11,13 @@ updates:
       all:
         patterns:
         - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      pgstac:
+        dependency-type: "development"
+        patterns:
+        - "pypgstac*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
@@ -37,12 +37,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: install lib postgres
-        run: |
-          sudo apt update
-          wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O- | sudo apt-key add -
-          echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" | sudo tee /etc/apt/sources.list.d/postgresql.list
-          sudo apt update
-          sudo apt-get install --yes libpq-dev postgis postgresql-14-postgis-3
+        uses: nyurik/action-setup-postgis@v2
 
       - name: Install dependencies
         run: |
@@ -69,29 +64,24 @@ jobs:
 
   benchmark:
     needs: [tests]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
-      PGSTAC_VERSION: '0.8.1'
+      PGSTAC_VERSION: '0.9'
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ env.LATEST_PY_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ env.LATEST_PY_VERSION }}
 
       - name: Launch services
-        run: docker-compose up -d tiler-uvicorn
+        run: docker compose up -d tiler-uvicorn
         env:
           PGSTAC_VERSION: ${{ env.PGSTAC_VERSION }}
 
       - name: install lib postgres
-        run: |
-          sudo apt update
-          wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O- | sudo apt-key add -
-          echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" | sudo tee /etc/apt/sources.list.d/postgresql.list
-          sudo apt update
-          sudo apt-get install --yes libpq-dev postgis postgresql-14-postgis-3
+        uses: nyurik/action-setup-postgis@v2
 
       - name: Install python dependencies
         run: |
@@ -127,7 +117,7 @@ jobs:
           auto-push: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Stop services
-        run: docker-compose stop
+        run: docker compose stop
 
   publish:
     needs: [tests]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     needs: [tests]
     runs-on: ubuntu-latest
     env:
-      PGSTAC_VERSION: '0.9'
+      PGSTAC_VERSION: '0.9.1'
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ $ uvicorn titiler.pgstac.main:app --reload
 ```
 $ git clone https://github.com/stac-utils/titiler-pgstac.git
 $ cd titiler-pgstac
-$ docker-compose up --build tiler
+$ docker compose up --build tiler
 ```
 
 It runs `titiler.pgstac` using Gunicorn web server. To run Uvicorn based version:
 
 ```
-$ docker-compose up --build tiler-uvicorn
+$ docker compose up --build tiler-uvicorn
 ```
 
 ## Contribution & Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ test = [
     "pytest-cov",
     "pytest-asyncio",
     "httpx",
-    "pypgstac>=0.7,<0.10",
+    "pypgstac>=0.7,<=0.9.1",
     "psycopg2",
     "pytest-pgsql",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ test = [
     "pytest-cov",
     "pytest-asyncio",
     "httpx",
-    "pypgstac>=0.8",
+    "pypgstac>=0.7,<0.10",
     "psycopg2",
     "pytest-pgsql",
 ]


### PR DESCRIPTION
closes #171 

We don't really need to run the CI on multiple pgstac version (except if start changing how we register searches) 

This PR adds a Dependabot config to make sure we get an alert (and run CI) on pypgstac update