### PR TITLE
add cachecontrol_exclude_paths in ApiSettings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+
+* add `cachecontrol_exclude_paths` attribute in `ApiSettings` to let users decide if some path should not have cache-control headers (defaults is to exclude `/list`)
+
 ## 1.3.1 (2024-08-01)
 
 * update models to avoid pydantic deprecation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,8 +101,8 @@ def app(database_url, monkeypatch):
     from titiler.pgstac.main import app
 
     # Remove middlewares https://github.com/encode/starlette/issues/472
-    app.user_middleware = []
-    app.middleware_stack = app.build_middleware_stack()
+    # app.user_middleware = []
+    # app.middleware_stack = app.build_middleware_stack()
 
     with TestClient(app) as app:
         yield app

--- a/tests/test_searches.py
+++ b/tests/test_searches.py
@@ -1043,3 +1043,16 @@ def test_query_point_searches(app, search_no_bbox, search_bbox):
     )
 
     assert response.status_code == 204  # (no content)
+
+
+def test_cache_middleware_settings(app, search_no_bbox):
+    """Make sure some endpoints do not have cache-control headers."""
+    response = app.get("/searches/list")
+    assert response.status_code == 200
+    assert not response.headers.get("Cache-Control")
+
+    response = app.get(
+        f"/searches/{search_no_bbox}/point/-85.5,36.1624", params={"assets": "cog"}
+    )
+    assert response.status_code == 200
+    assert response.headers.get("Cache-Control")

--- a/titiler/pgstac/main.py
+++ b/titiler/pgstac/main.py
@@ -101,7 +101,11 @@ if settings.cors_origins:
         allow_headers=["*"],
     )
 
-app.add_middleware(CacheControlMiddleware, cachecontrol=settings.cachecontrol)
+app.add_middleware(
+    CacheControlMiddleware,
+    cachecontrol=settings.cachecontrol,
+    exclude_path=settings.cachecontrol_exclude_paths,
+)
 
 optional_headers = []
 if settings.debug:

--- a/titiler/pgstac/settings.py
+++ b/titiler/pgstac/settings.py
@@ -1,7 +1,7 @@
 """API settings."""
 
 from functools import lru_cache
-from typing import Any, Optional
+from typing import Any, Optional, Set
 
 from pydantic import (
     Field,
@@ -20,6 +20,11 @@ class ApiSettings(BaseSettings):
     name: str = "titiler-pgstac"
     cors_origins: str = "*"
     cachecontrol: str = "public, max-age=3600"
+    cachecontrol_exclude_paths: Set[str] = Field(
+        default={
+            ".+/list",
+        }
+    )
     root_path: str = ""
     debug: bool = False
 


### PR DESCRIPTION
closes #174 

@drnextgis do you see other paths that should be excluded by default? 