### PR TITLE
switch to pytest-postgresql

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,7 @@ test = [
     "pytest-asyncio",
     "httpx",
     "pypgstac>=0.7,<=0.9.1",
-    "psycopg2",
-    "pytest-pgsql",
+    "pytest-postgresql",
 ]
 
 [project.urls]

--- a/titiler/pgstac/settings.py
+++ b/titiler/pgstac/settings.py
@@ -2,6 +2,7 @@
 
 from functools import lru_cache
 from typing import Any, Optional, Set
+from urllib.parse import quote_plus as quote
 
 from pydantic import (
     Field,
@@ -83,8 +84,8 @@ class PostgresSettings(BaseSettings):
 
         return PostgresDsn.build(
             scheme="postgresql",
-            username=info.data.get("postgres_user"),
-            password=info.data.get("postgres_pass"),
+            username=info.data["postgres_user"],
+            password=quote(info.data["postgres_pass"]),
             host=info.data.get("postgres_host", ""),
             port=info.data.get("postgres_port", 5432),
             path=info.data.get("postgres_dbname", ""),


### PR DESCRIPTION
This PR does:
- switch to `pytest-postgresql` from `pytest-psql` which is no more maintained
- use quote-plus to encode postgres password https://github.com/stac-utils/stac-fastapi-pgstac/pull/122