### PR TITLE
Disable testing of pre-0.9 versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* disable tests for pre-0.9 pgstac versions
+
 ## 2.0.0 (2026-01-13)
 
 * change environment variable names for Postgres database connection **breaking change**

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,8 +75,6 @@ def load_json(filepath: str):
 
 @pytest.fixture(
     params=[
-        "0.7.10",
-        "0.8.5",
         "0.9.8",
     ],
     scope="session",


### PR DESCRIPTION
Closes #252 

Disables testing of pre-0.9 pgstac versions as suggested in [this comment](https://github.com/stac-utils/titiler-pgstac/issues/252#issuecomment-3828735480).

Executing tests against older pgstac versions could fail depending on the postgres version used with pgstac, and older pgstac versions are no longer considered relevant in testing. This change streamlines testing and avoids potential issues related to postgres version.
