### PR TITLE
fix: exclude /healthz from default Cache-Control paths.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+* Exclude `/healthz` from default `Cache-Control` middleware paths.
+
 ## 3.0.0 (2026-06-01)
 
 * change: update titiler requirement to `>=2.0,<2.1`

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -10,6 +10,7 @@ def test_database_online(app):
     """check health endpoints."""
     response = app.get("/healthz")
     assert response.status_code == 200
+    assert not response.headers.get("Cache-Control")
     resp = response.json()
     assert resp["database_online"]
 

--- a/titiler/pgstac/settings.py
+++ b/titiler/pgstac/settings.py
@@ -22,6 +22,7 @@ class ApiSettings(BaseSettings):
     cachecontrol: str = "public, max-age=3600"
     cachecontrol_exclude_paths: set[str] = Field(
         default={
+            "/healthz",
             ".+/list",
         }
     )


### PR DESCRIPTION
## Technical Context
- **Breaking Changes:** No

## Description

Default `Cache-Control` is public, `max-age=3600`. Without this exclude, probes can cache a healthy (or unhealthy) response for an hour. This is not ideal for k8s/load balancers and ops.

---

## Checklist
- [x] **Linting:** Code is formatted and linted
- [x] **Tests:** Tests pass. I have included new tests for these changes where applicable.
- [ ] **Edge Cases:** I have manually verified "unhappy paths" and edge cases beyond the basic success criteria (e.g., database connection timeouts, malformed input, strict mapping rejections).
- [x] **Documentation:** No need for `README.md`, added to `CHANGES.md`
- [x] **Accountability:** I can explain the implementation logic for every line of code submitted.

---

## AI tool usage
 - [x] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://stac-utils.github.io/ai-contribution-policy). Use of AI tools *must* be indicated.
 ---
 > **Policy:** We require a "human-in-the-loop." You are the author and are fully accountable for all submitted code. Please ensure all tool-generated content is thoroughly reviewed before submission to ensure it is not an "extractive contribution" that squanders maintainer time.